### PR TITLE
core: utils: http: use default json parsing for price reporter fetch

### DIFF
--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -58,6 +58,11 @@ export async function getRelayerRaw(url: string, headers = {}) {
               return value
             })
           }
+
+          if (url.includes('/price')) {
+            return JSON.parse(data)
+          }
+
           return parseBigJSON(data)
         } catch (_error) {
           return data


### PR DESCRIPTION
This PR adds a clause for the price reporter's `/price` route in the `getRelayerRaw` method that ensures the result is not parsed using `parseBigJSON`.

This is currently what happens, but for float prices it would error and we would just `return data` directly, i.e. the `number` type.

However, whole number prices would get successfully parsed into `BigInt`s, violating the return type expected in the `getPriceFromPriceReporter` function signature.