### PR TITLE
node: export actions from entry module

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/node
 
+## 0.3.5
+
+### Patch Changes
+
+- node: export actions from entry module
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/src/exports/actions.ts
+++ b/packages/node/src/exports/actions.ts
@@ -1,2 +1,8 @@
-export * from '../actions/executeDeposit.js'
-export * from '../actions/executeWithdrawal.js'
+export {
+  executeDeposit,
+  type ExecuteDepositParameters,
+} from '../actions/executeDeposit.js'
+export {
+  executeWithdrawal,
+  type ExecuteWithdrawalParameters,
+} from '../actions/executeWithdrawal.js'

--- a/packages/node/src/exports/index.ts
+++ b/packages/node/src/exports/index.ts
@@ -17,3 +17,16 @@ function createConfig(
 }
 
 export { createConfig }
+
+////////////////////////////////////////////////////////////////////////////////
+// Actions
+////////////////////////////////////////////////////////////////////////////////
+
+export {
+  executeDeposit,
+  type ExecuteDepositParameters,
+} from '../actions/executeDeposit.js'
+export {
+  executeWithdrawal,
+  type ExecuteWithdrawalParameters,
+} from '../actions/executeWithdrawal.js'


### PR DESCRIPTION
This PR ensures actions in the `node` package are also exported from the entry module in addition to the `/actions` namespace.