### PR TITLE
core: expose limit parameter for getOrderHistory

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.3.4
+
+### Patch Changes
+
+- core: expose limit parameter for getOrderHistory
+
 ## 0.3.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -68,6 +68,9 @@ export const PAY_FEES_ROUTE = (wallet_id: string) =>
 // Returns the order history of a wallet
 export const ORDER_HISTORY_ROUTE = (wallet_id: string) =>
   `/wallet/${wallet_id}/order-history`
+/// The name of the query parameter specifying the length of the order history
+/// to return
+export const ORDER_HISTORY_LEN_PARAM = 'order_history_len'
 
 ////////////////////////////////////////////////////////////////////////////////
 // Network

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -78,6 +78,7 @@ export {
 } from '../actions/getOrder.js'
 
 export {
+  type GetOrderHistoryParameters,
   type GetOrderHistoryErrorType,
   type GetOrderHistoryReturnType,
   getOrderHistory,

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.3.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.3.4
+
 ## 0.3.5
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.3.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.3.4
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.3.4
+
 ## 0.2.4
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
This PR exposes a `limit` parameter for the `getOrderHistory` action that allows for consumers to limit the response sent from the API server.