### PR TITLE
core: actions: add getOrderMatchingPool action

### DIFF
--- a/packages/core/src/actions/getOrderMatchingPool.ts
+++ b/packages/core/src/actions/getOrderMatchingPool.ts
@@ -1,0 +1,30 @@
+import { ADMIN_GET_ORDER_MATCHING_POOL_ROUTE } from '../constants.js'
+import type { Config } from '../createConfig.js'
+import { getRelayerWithAdmin } from '../utils/http.js'
+
+export type GetOrderMatchingPoolParameters = {
+  orderId: string
+}
+
+export type GetOrderMatchingPoolReturnType = string
+
+export async function getOrderMatchingPool(
+  config: Config,
+  parameters: GetOrderMatchingPoolParameters,
+): Promise<GetOrderMatchingPoolReturnType> {
+  const { orderId } = parameters
+  const { getRelayerBaseUrl } = config
+
+  try {
+    const res = await getRelayerWithAdmin(
+      config,
+      getRelayerBaseUrl(ADMIN_GET_ORDER_MATCHING_POOL_ROUTE(orderId)),
+    )
+
+    return res.matching_pool
+  } catch (error) {
+    console.error(`Failed to get matching pool for order ${orderId}`, { error })
+
+    throw error
+  }
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -172,6 +172,9 @@ export const ADMIN_ASSIGN_ORDER_ROUTE = (
   order_id: string,
   matching_pool: string,
 ) => `/admin/orders/${order_id}/assign-pool/${matching_pool}`
+// Route to get the matching pool for an order
+export const ADMIN_GET_ORDER_MATCHING_POOL_ROUTE = (order_id: string) =>
+  `/admin/orders/${order_id}/matching-pool`
 
 ////////////////////////////////////////////////////////////////////////////////
 // Price Reporter

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -86,6 +86,12 @@ export {
 } from '../actions/getOrderHistory.js'
 
 export {
+  type GetOrderMatchingPoolParameters,
+  type GetOrderMatchingPoolReturnType,
+  getOrderMatchingPool,
+} from '../actions/getOrderMatchingPool.js'
+
+export {
   type GetOrderMetadataParameters,
   type GetOrderMetadataReturnType,
   type GetOrderMetadataErrorType,

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -85,6 +85,12 @@ export {
 } from '../actions/getOrderHistory.js'
 
 export {
+  type GetOrderMatchingPoolParameters,
+  type GetOrderMatchingPoolReturnType,
+  getOrderMatchingPool,
+} from '../actions/getOrderMatchingPool.js'
+
+export {
   type GetOrdersReturnType,
   getOrders,
 } from '../actions/getOrders.js'


### PR DESCRIPTION
This PR adds an SDK action for the new "get order matching pool" relayer endpoint