### PR TITLE
core: actions: getOpenOrders, getOrderMetadata: use new response shapes

### DIFF
--- a/packages/core/src/actions/getOpenOrders.ts
+++ b/packages/core/src/actions/getOpenOrders.ts
@@ -1,15 +1,13 @@
 import { ADMIN_OPEN_ORDERS_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { OpenOrder } from '../types/order.js'
 import { getRelayerWithAdmin } from '../utils/http.js'
 
 export type GetOpenOrdersParams = {
   matchingPool?: string
-  includeFillable?: boolean
 }
 
-export type GetOpenOrdersReturnType = Map<string, OpenOrder>
+export type GetOpenOrdersReturnType = string[]
 
 export type GetOpenOrdersErrorType = BaseErrorType
 
@@ -25,14 +23,10 @@ export async function getOpenOrders(
     url.searchParams.set('matching_pool', parameters.matchingPool)
   }
 
-  if (parameters.includeFillable) {
-    url.searchParams.set('include_fillable', String(true))
-  }
-
   const res = await getRelayerWithAdmin(config, url.toString())
 
   if (!res.orders) {
     throw new BaseError('No orders found')
   }
-  return new Map(res.orders.map((order: OpenOrder) => [order.order.id, order]))
+  return res.orders
 }

--- a/packages/core/src/actions/getOrderMetadata.ts
+++ b/packages/core/src/actions/getOrderMetadata.ts
@@ -1,12 +1,15 @@
 import { ADMIN_ORDER_METADATA_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { OrderMetadata } from '../types/order.js'
+import type { AdminOrderMetadata } from '../types/order.js'
 import { getRelayerWithAdmin } from '../utils/http.js'
 
-export type GetOrderMetadataParameters = { id: string }
+export type GetOrderMetadataParameters = {
+  id: string
+  includeFillable?: boolean
+}
 
-export type GetOrderMetadataReturnType = OrderMetadata
+export type GetOrderMetadataReturnType = AdminOrderMetadata
 
 export type GetOrderMetadataErrorType = BaseErrorType
 
@@ -17,10 +20,13 @@ export async function getOrderMetadata(
   const { id } = parameters
   const { getRelayerBaseUrl } = config
 
-  const res = await getRelayerWithAdmin(
-    config,
-    getRelayerBaseUrl(ADMIN_ORDER_METADATA_ROUTE(id)),
-  )
+  const url = new URL(getRelayerBaseUrl(ADMIN_ORDER_METADATA_ROUTE(id)))
+
+  if (parameters.includeFillable) {
+    url.searchParams.set('include_fillable', String(true))
+  }
+
+  const res = await getRelayerWithAdmin(config, url.toString())
 
   if (!res.order) {
     throw new BaseError('No order found')

--- a/packages/core/src/actions/getWalletOrderIds.ts
+++ b/packages/core/src/actions/getWalletOrderIds.ts
@@ -1,0 +1,31 @@
+import { ADMIN_WALLET_ORDER_IDS_ROUTE } from '../constants.js'
+import type { Config } from '../createConfig.js'
+import { BaseError, type BaseErrorType } from '../errors/base.js'
+import { getRelayerWithAdmin } from '../utils/http.js'
+
+export type GetWalletOrderIdsParameters = {
+  id: string
+}
+
+export type GetWalletOrderIdsReturnType = string[]
+
+export type GetWalletOrderIdsErrorType = BaseErrorType
+
+export async function getWalletOrderIds(
+  config: Config,
+  parameters: GetWalletOrderIdsParameters,
+): Promise<GetWalletOrderIdsReturnType> {
+  const { id } = parameters
+  const { getRelayerBaseUrl } = config
+
+  const res = await getRelayerWithAdmin(
+    config,
+    getRelayerBaseUrl(ADMIN_WALLET_ORDER_IDS_ROUTE(id)),
+  )
+
+  if (!res.order_ids) {
+    throw new BaseError('No orders found')
+  }
+
+  return res.order_ids
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -175,6 +175,9 @@ export const ADMIN_ASSIGN_ORDER_ROUTE = (
 // Route to get the matching pool for an order
 export const ADMIN_GET_ORDER_MATCHING_POOL_ROUTE = (order_id: string) =>
   `/admin/orders/${order_id}/matching-pool`
+// Route to get all the order IDs for a given wallet
+export const ADMIN_WALLET_ORDER_IDS_ROUTE = (wallet_id: string) =>
+  `/admin/wallet/${wallet_id}/order-ids`
 
 ////////////////////////////////////////////////////////////////////////////////
 // Price Reporter

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -179,6 +179,10 @@ export const ADMIN_GET_ORDER_MATCHING_POOL_ROUTE = (order_id: string) =>
 export const ADMIN_WALLET_ORDER_IDS_ROUTE = (wallet_id: string) =>
   `/admin/wallet/${wallet_id}/order-ids`
 
+// The admin wallet updates topic, streams opaque event indicating
+// updates for all wallets
+export const WS_ADMIN_WALLET_UPDATES_ROUTE = '/v0/admin/wallet-updates'
+
 ////////////////////////////////////////////////////////////////////////////////
 // Price Reporter
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -156,6 +156,13 @@ export {
 } from '../actions/getWalletId.js'
 
 export {
+  type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
+  type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
+  type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
+  getWalletOrderIds as getWalletOrders,
+} from '../actions/getWalletOrderIds.js'
+
+export {
   type LookupWalletReturnType,
   lookupWallet,
 } from '../actions/lookupWallet.js'

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -159,7 +159,7 @@ export {
   type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
   type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
   type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
-  getWalletOrderIds as getWalletOrders,
+  getWalletOrderIds,
 } from '../actions/getWalletOrderIds.js'
 
 export {

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -151,7 +151,7 @@ export {
   type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
   type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
   type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
-  getWalletOrderIds as getWalletOrders,
+  getWalletOrderIds,
 } from '../actions/getWalletOrderIds.js'
 
 export {

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -148,6 +148,13 @@ export {
 } from '../actions/getWalletId.js'
 
 export {
+  type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
+  type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
+  type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
+  getWalletOrderIds as getWalletOrders,
+} from '../actions/getWalletOrderIds.js'
+
+export {
   type LookupWalletReturnType,
   lookupWallet,
 } from '../actions/lookupWallet.js'

--- a/packages/core/src/types/order.ts
+++ b/packages/core/src/types/order.ts
@@ -40,7 +40,7 @@ export type TimestampedPrice = {
   timestamp: bigint
 }
 
-export type OpenOrder = {
+export type AdminOrderMetadata = {
   order: OrderMetadata
   wallet_id: string
   fillable?: bigint


### PR DESCRIPTION
This PR brings the `getOpenOrders` and `getOrderMetadata` actions in sync w/ the new response shapes used by the relayer