### PR TITLE
core, node, react: export ws types correctly

### DIFF
--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -281,11 +281,14 @@ export { deepEqual } from '../utils/deepEqual.js'
 export { postRelayerRaw } from '../utils/http.js'
 
 export {
+  AuthType,
   RelayerWebsocket,
   type RelayerWebsocketParams,
-  type AuthType,
 } from '../utils/websocket.js'
 
-export { websocketWaiter } from '../utils/websocketWaiter.js'
+export {
+  websocketWaiter,
+  type WebsocketWaiterParams,
+} from '../utils/websocketWaiter.js'
 
 export { parseBigJSON, stringifyForWasm } from '../utils/bigJSON.js'

--- a/packages/node/src/exports/index.ts
+++ b/packages/node/src/exports/index.ts
@@ -37,7 +37,7 @@ export {
 
 export {
   // WebSocket
+  AuthType,
   RelayerWebsocket,
   type RelayerWebsocketParams,
-  type AuthType,
 } from '@renegade-fi/core'

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -232,7 +232,7 @@ export {
   Token,
   UpdateType,
   // WebSocket
+  AuthType,
   RelayerWebsocket,
   type RelayerWebsocketParams,
-  type AuthType,
 } from '@renegade-fi/core'


### PR DESCRIPTION
This PR ensures the types from the websocket utility changes are properly exported