### PR TITLE
core: utils: http: parse BigInt values directly from JSON source

### DIFF
--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -51,9 +51,18 @@ export async function getRelayerRaw(url: string, headers = {}) {
             url.includes('/open-orders') ||
             url.includes('/metadata')
           ) {
-            return JSON.parse(data, (key, value) => {
+            // We use ts-ignore here because TypeScript doesn't recognize the
+            // `context` argument in the JSON.parse reviver
+            // @ts-ignore
+            return JSON.parse(data, (key, value, context) => {
               if (typeof value === 'number' && key !== 'price') {
-                return BigInt(value)
+                if (context?.source === undefined) {
+                  console.warn(
+                    `No JSON source for ${key}, converting parsed value to BigInt`,
+                  )
+                  return BigInt(value)
+                }
+                return BigInt(context.source)
               }
               return value
             })


### PR DESCRIPTION
This PR fixes the special-case `BigInt` JSON parsing for endpoints that return both floating-point and integer types to parse the JSON source directly into a BigInt, as opposed to the number type resulting from the "first round" of JSON parsing.