### PR TITLE
core: actions: admin get wallet order IDs action

### DIFF
--- a/packages/core/src/actions/getWalletOrderIds.ts
+++ b/packages/core/src/actions/getWalletOrderIds.ts
@@ -1,0 +1,31 @@
+import { ADMIN_WALLET_ORDER_IDS_ROUTE } from '../constants.js'
+import type { Config } from '../createConfig.js'
+import { BaseError, type BaseErrorType } from '../errors/base.js'
+import { getRelayerWithAdmin } from '../utils/http.js'
+
+export type GetWalletOrderIdsParameters = {
+  id: string
+}
+
+export type GetWalletOrderIdsReturnType = string[]
+
+export type GetWalletOrderIdsErrorType = BaseErrorType
+
+export async function getWalletOrderIds(
+  config: Config,
+  parameters: GetWalletOrderIdsParameters,
+): Promise<GetWalletOrderIdsReturnType> {
+  const { id } = parameters
+  const { getRelayerBaseUrl } = config
+
+  const res = await getRelayerWithAdmin(
+    config,
+    getRelayerBaseUrl(ADMIN_WALLET_ORDER_IDS_ROUTE(id)),
+  )
+
+  if (!res.order_ids) {
+    throw new BaseError('No orders found')
+  }
+
+  return res.order_ids
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -175,6 +175,9 @@ export const ADMIN_ASSIGN_ORDER_ROUTE = (
 // Route to get the matching pool for an order
 export const ADMIN_GET_ORDER_MATCHING_POOL_ROUTE = (order_id: string) =>
   `/admin/orders/${order_id}/matching-pool`
+// Route to get all the order IDs for a given wallet
+export const ADMIN_WALLET_ORDER_IDS_ROUTE = (wallet_id: string) =>
+  `/admin/wallet/${wallet_id}/order-ids`
 
 ////////////////////////////////////////////////////////////////////////////////
 // Price Reporter

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -156,6 +156,13 @@ export {
 } from '../actions/getWalletId.js'
 
 export {
+  type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
+  type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
+  type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
+  getWalletOrderIds as getWalletOrders,
+} from '../actions/getWalletOrderIds.js'
+
+export {
   type LookupWalletReturnType,
   lookupWallet,
 } from '../actions/lookupWallet.js'

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -148,6 +148,13 @@ export {
 } from '../actions/getWalletId.js'
 
 export {
+  type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
+  type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
+  type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
+  getWalletOrderIds as getWalletOrders,
+} from '../actions/getWalletOrderIds.js'
+
+export {
   type LookupWalletReturnType,
   lookupWallet,
 } from '../actions/lookupWallet.js'


### PR DESCRIPTION
This PR adds an admin action for fetching the order IDs associated with a wallet in accordance with https://github.com/renegade-fi/renegade/pull/802

This will be tested downstream of consumption in the internal bot server