### PR TITLE
core: constants: export admin wallet updates ws route

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -179,6 +179,10 @@ export const ADMIN_GET_ORDER_MATCHING_POOL_ROUTE = (order_id: string) =>
 export const ADMIN_WALLET_ORDER_IDS_ROUTE = (wallet_id: string) =>
   `/admin/wallet/${wallet_id}/order-ids`
 
+// The admin wallet updates topic, streams opaque event indicating
+// updates for all wallets
+export const WS_ADMIN_WALLET_UPDATES_ROUTE = '/v0/admin/wallet-updates'
+
 ////////////////////////////////////////////////////////////////////////////////
 // Price Reporter
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -159,7 +159,7 @@ export {
   type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
   type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
   type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
-  getWalletOrderIds as getWalletOrders,
+  getWalletOrderIds,
 } from '../actions/getWalletOrderIds.js'
 
 export {

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -151,7 +151,7 @@ export {
   type GetWalletOrderIdsParameters as GetWalletOrdersParameters,
   type GetWalletOrderIdsReturnType as GetWalletOrdersReturnType,
   type GetWalletOrderIdsErrorType as GetWalletOrdersErrorType,
-  getWalletOrderIds as getWalletOrders,
+  getWalletOrderIds,
 } from '../actions/getWalletOrderIds.js'
 
 export {


### PR DESCRIPTION
This PR exports the new admin wallet updates websocket route from the SDK (and fixes the exports of the "get order IDs for wallet" action)