### PR TITLE
wasm: include public blinder to create-wallet

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.4.0
+
+### Minor Changes
+
+- wasm: include public blinder in create-wallet
+
 ## 0.3.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @renegade-fi/node
 
+## 0.4.0
+
+### Minor Changes
+
+- wasm: include public blinder in create-wallet
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.0
+
 ## 0.3.11
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @renegade-fi/react
 
+## 0.4.0
+
+### Minor Changes
+
+- wasm: include public blinder in create-wallet
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @renegade-fi/test
 
+## 0.3.0
+
+### Minor Changes
+
+- wasm: include public blinder in create-wallet
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.0
+
 ## 0.2.9
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -53,14 +53,19 @@ pub struct WalletUpdateAuthorization {
 pub struct CreateWalletRequest {
     /// The wallet info to be created
     pub wallet: ApiWallet,
+    /// The seed for the wallet's blinder CSPRNG
+    pub blinder_seed: BigUint,
 }
 
 #[wasm_bindgen]
 pub fn create_wallet(seed: &str) -> Result<JsValue, JsError> {
     let sk_root = derive_sk_root_signing_key(&seed, None).unwrap();
-    let (mut wallet, _, _) = derive_wallet_from_key(&sk_root).unwrap();
+    let (mut wallet, blinder_seed, _) = derive_wallet_from_key(&sk_root).unwrap();
     wallet.key_chain.private_keys.delete_sk_root();
-    let req = CreateWalletRequest { wallet };
+    let req = CreateWalletRequest {
+        wallet,
+        blinder_seed: blinder_seed.to_biguint(),
+    };
 
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))
 }


### PR DESCRIPTION
### Purpose
This PR includes the blinder seed derived from a wallet seed so the relayer is able to verify this to prevent blinder frontrunning as described in https://github.com/renegade-fi/renegade/pull/811.

### Testing
Tested locally, ensures that wallet is created when blinder seed is included in request, and fails to create when blinder seed is absent.