### PR TITLE
react: allow importing default export from es module

### DIFF
--- a/packages/react/src/hooks/useOrderBookWebSocket.ts
+++ b/packages/react/src/hooks/useOrderBookWebSocket.ts
@@ -25,7 +25,7 @@ export function useOrderBookWebSocket(
   const { getWebsocketBaseUrl } = config
   const { enabled = true, onUpdate } = parameters
 
-  const { readyState, sendJsonMessage } = useWebSocket.default(
+  const { readyState, sendJsonMessage } = useWebSocket(
     getWebsocketBaseUrl(),
     {
       filter: () => false,

--- a/packages/react/src/hooks/useOrderHistoryWebSocket.ts
+++ b/packages/react/src/hooks/useOrderHistoryWebSocket.ts
@@ -31,7 +31,7 @@ export function useOrderHistoryWebSocket(
   const { getWebsocketBaseUrl } = config
   const { enabled = true, onUpdate } = parameters
 
-  const { readyState, sendJsonMessage } = useWebSocket.default(
+  const { readyState, sendJsonMessage } = useWebSocket(
     getWebsocketBaseUrl(),
     {
       filter: () => false,

--- a/packages/react/src/hooks/useTaskHistoryWebSocket.ts
+++ b/packages/react/src/hooks/useTaskHistoryWebSocket.ts
@@ -32,7 +32,7 @@ export function useTaskHistoryWebSocket(
   const { enabled = true, onUpdate } = parameters
   const initialized = useInitialized()
 
-  const { readyState, sendJsonMessage } = useWebSocket.default(
+  const { readyState, sendJsonMessage } = useWebSocket(
     getWebsocketBaseUrl(),
     {
       filter: () => false,

--- a/packages/react/src/hooks/useWalletWebSocket.ts
+++ b/packages/react/src/hooks/useWalletWebSocket.ts
@@ -30,7 +30,7 @@ export function useWalletWebsocket(parameters: UseWalletParameters = {}) {
   const { getWebsocketBaseUrl } = config
   const { enabled = true, onUpdate } = parameters
 
-  const { readyState, sendJsonMessage } = useWebSocket.default(
+  const { readyState, sendJsonMessage } = useWebSocket(
     getWebsocketBaseUrl(),
     {
       filter: () => false,

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -3,6 +3,8 @@
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"],
   "compilerOptions": {
-    "sourceMap": true
+    "sourceMap": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext"
   }
 }


### PR DESCRIPTION
This PR adjusts TypeScript configuration to allow for ES Modules to be imported using their default export, specifically in the `/react` subpackage. This allows us to remove non-standard `.default` from the `react-use-websocket` library which was causing build issues in some bundlers of consumers.