### PR TITLE
wasm, core, react, node: add action to request external match bundles

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.4.2
+
+### Patch Changes
+
+- wasm, core, react, node: add action to request external match bundles
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -5,6 +5,8 @@ import type { Address } from 'viem'
 export const RENEGADE_AUTH_HEADER_NAME = 'x-renegade-auth'
 /// Header name for the expiration timestamp of a signature
 export const RENEGADE_SIG_EXPIRATION_HEADER_NAME = 'x-renegade-auth-expiration'
+/// The Renegade API key header
+export const RENEGADE_API_KEY_HEADER = 'x-renegade-api-key'
 /// The message used to derive the wallet's root key
 export const ROOT_KEY_MESSAGE_PREFIX =
   'Unlock your Renegade Wallet on chain ID:'
@@ -199,6 +201,13 @@ export const PRICE_REPORTER_ROUTE = (
   base: Address,
   quote: Address,
 ) => `/price/${PRICE_REPORTER_TOPIC(exchange, base, quote)}`
+
+////////////////////////////////////////////////////////////////////////////////
+// External Match
+////////////////////////////////////////////////////////////////////////////////
+/// The route for requesting an external match
+export const REQUEST_EXTERNAL_MATCH_ROUTE =
+  '/matching-engine/request-external-match'
 
 ////////////////////////////////////////////////////////////////////////////////
 // Token

--- a/packages/core/src/createAuthConfig.ts
+++ b/packages/core/src/createAuthConfig.ts
@@ -1,0 +1,43 @@
+import invariant from 'tiny-invariant'
+import type { BaseConfig } from './createConfig.js'
+import type * as rustUtils from './utils.d.ts'
+
+export type CreateAuthConfigParameters = {
+  apiKey: string
+  apiSecret: string
+  authServerUrl: string
+  utils?: typeof rustUtils
+}
+
+/**
+ * Creates a configuration object specifically for authenticating with the relayer authentication server.
+ * This is distinct from the main config (created by `createConfig`) which handles wallet operations.
+ *
+ * While `createConfig` is used for wallet-related interactions with the relayer (like creating orders
+ * or managing wallet state), this auth config is solely for endpoints that require API key authentication,
+ * such as external match requests of external orders.
+ */
+export function createAuthConfig(
+  parameters: CreateAuthConfigParameters,
+): AuthConfig {
+  const { apiKey, apiSecret, authServerUrl } = parameters
+  invariant(
+    parameters.utils,
+    'Utils must be provided by the package if not supplied by the user.',
+  )
+  return {
+    utils: parameters.utils,
+    apiKey,
+    apiSecret,
+    getAuthServerUrl: (route = '') => {
+      const formattedRoute = route.startsWith('/') ? route : `/${route}`
+      return `${authServerUrl}/v0${formattedRoute}`
+    },
+  }
+}
+
+export type AuthConfig = BaseConfig & {
+  apiSecret: string
+  apiKey: string
+  getAuthServerUrl: (route?: string) => string
+}

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -163,7 +163,11 @@ export function createConfig(parameters: CreateConfigParameters): Config {
   }
 }
 
-export type Config = {
+export type BaseConfig = {
+  utils: typeof rustUtils
+}
+
+export type Config = BaseConfig & {
   readonly storage: Storage | null
   darkPoolAddress: Address
   getPriceReporterBaseUrl: () => string
@@ -185,7 +189,6 @@ export type Config = {
         }
       | undefined,
   ): () => void
-  utils: typeof rustUtils
   viemClient: PublicClient
   adminKey?: string
   /**

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -50,6 +50,13 @@ export {
 export { type DisconnectReturnType, disconnect } from '../actions/disconnect.js'
 
 export {
+  type GetExternalMatchBundleParameters,
+  type GetExternalMatchBundleReturnType,
+  type GetExternalMatchBundleErrorType,
+  getExternalMatchBundle,
+} from '../actions/getExternalMatchBundle.js'
+
+export {
   type GetBalancesReturnType,
   getBalances,
 } from '../actions/getBalances.js'

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -54,6 +54,13 @@ export {
 } from '../actions/disconnect.js'
 
 export {
+  type GetExternalMatchBundleParameters,
+  type GetExternalMatchBundleReturnType,
+  type GetExternalMatchBundleErrorType,
+  getExternalMatchBundle,
+} from '../actions/getExternalMatchBundle.js'
+
+export {
   type GetBalancesReturnType,
   getBalances,
 } from '../actions/getBalances.js'
@@ -214,11 +221,18 @@ export * from './constants.js'
 ////////////////////////////////////////////////////////////////////////////////
 
 export {
+  type BaseConfig,
   type Config,
   type CreateConfigParameters,
   type State,
   createConfig,
 } from '../createConfig.js'
+
+export {
+  type AuthConfig,
+  type CreateAuthConfigParameters,
+  createAuthConfig,
+} from '../createAuthConfig.js'
 
 ////////////////////////////////////////////////////////////////////////////////
 // createStorage

--- a/packages/core/src/types/externalOrder.ts
+++ b/packages/core/src/types/externalOrder.ts
@@ -1,0 +1,22 @@
+import type { AccessList } from 'viem'
+
+export type ExternalMatchResult = {
+  quote_mint: `0x${string}`
+  base_mint: `0x${string}`
+  direction: 'Buy' | 'Sell'
+  quote_amount: bigint
+  base_amount: bigint
+  min_fill_size: bigint
+}
+
+export type ExternalSettlementTx = {
+  type: `0x${string}`
+  to: `0x${string}`
+  data: `0x${string}`
+  accessList: AccessList
+}
+
+export type ExternalMatchBundle = {
+  match_result: ExternalMatchResult
+  settlement_tx: ExternalSettlementTx
+}

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -92,6 +92,15 @@ export function cancel_order(seed: string, wallet_str: string, order_id: string)
 */
 export function update_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean): any;
 /**
+* @param {string} base_mint
+* @param {string} quote_mint
+* @param {string} side
+* @param {string} amount
+* @param {string} min_fill_size
+* @returns {any}
+*/
+export function new_external_order(base_mint: string, quote_mint: string, side: string, amount: string, min_fill_size: string): any;
+/**
 * @param {string} path
 * @param {any} headers
 * @param {string} body

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -6,7 +6,7 @@ import {
   RENEGADE_SIG_EXPIRATION_HEADER_NAME,
   SIG_EXPIRATION_BUFFER_MS,
 } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { BaseConfig, Config } from '../createConfig.js'
 import { BaseError } from '../errors/base.js'
 import { parseBigJSON } from './bigJSON.js'
 
@@ -188,6 +188,32 @@ export async function getRelayerWithAdmin(config: Config, url: string) {
   return await getRelayerRaw(url, headersWithAuth)
 }
 
+export async function postWithSymmetricKey(
+  config: BaseConfig,
+  {
+    body,
+    headers = {},
+    key,
+    url,
+  }: {
+    body?: string
+    headers?: Record<string, string>
+    key: string
+    url: string
+  },
+) {
+  const path = getPathFromUrl(url)
+  const headersWithAuth = addExpiringAuthToHeaders(
+    config,
+    path,
+    headers,
+    body ?? '',
+    key,
+    SIG_EXPIRATION_BUFFER_MS,
+  )
+  return await postRelayerRaw(url, body, headersWithAuth)
+}
+
 /// Get the path from a URL
 function getPathFromUrl(url: string): string {
   try {
@@ -200,7 +226,7 @@ function getPathFromUrl(url: string): string {
 
 /// Add an auth expiration and signature to a set of headers
 export function addExpiringAuthToHeaders(
-  config: Config,
+  config: BaseConfig,
   path: string,
   headers: Record<string, string>,
   body: string,

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.4.2
+
+### Patch Changes
+
+- wasm, core, react, node: add action to request external match bundles
+- Updated dependencies
+  - @renegade-fi/core@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/src/exports/index.ts
+++ b/packages/node/src/exports/index.ts
@@ -2,7 +2,10 @@ export * from '@renegade-fi/core'
 export * from '@renegade-fi/core/actions'
 export * from '@renegade-fi/core/constants'
 
-import { createConfig as core_createConfig } from '@renegade-fi/core'
+import {
+  createAuthConfig as core_createAuthConfig,
+  createConfig as core_createConfig,
+} from '@renegade-fi/core'
 
 import * as RustUtils from '../../renegade-utils/index.js'
 
@@ -16,7 +19,17 @@ function createConfig(
   return config
 }
 
-export { createConfig }
+function createAuthConfig(
+  ...args: Parameters<typeof core_createAuthConfig>
+): ReturnType<typeof core_createAuthConfig> {
+  const config = core_createAuthConfig({
+    ...args[0],
+    utils: RustUtils,
+  })
+  return config
+}
+
+export { createAuthConfig, createConfig }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Actions

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/react
 
+## 0.4.2
+
+### Patch Changes
+
+- wasm, core, react, node: add action to request external match bundles
+- Updated dependencies
+  - @renegade-fi/core@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -1,7 +1,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 // createConfig
 ////////////////////////////////////////////////////////////////////////////////
-import { createConfig as core_createConfig } from '@renegade-fi/core'
+import {
+  createAuthConfig as core_createAuthConfig,
+  createConfig as core_createConfig,
+} from '@renegade-fi/core'
 
 import * as RustUtils from '../../renegade-utils/index.js'
 
@@ -15,7 +18,17 @@ function createConfig(
   return config
 }
 
-export { createConfig }
+function createAuthConfig(
+  ...args: Parameters<typeof core_createAuthConfig>
+): ReturnType<typeof core_createAuthConfig> {
+  const config = core_createAuthConfig({
+    ...args[0],
+    utils: RustUtils,
+  })
+  return config
+}
+
+export { createAuthConfig, createConfig }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Context

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.2
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/wasm/src/external_api/auth/auth_helpers.rs
+++ b/wasm/src/external_api/auth/auth_helpers.rs
@@ -19,7 +19,6 @@ pub fn create_request_signature(
 
     let headers: HashMap<String, String> = serde_wasm_bindgen::from_value(headers)
         .map_err(|e| JsError::new(&format!("Failed to deserialize headers: {}", e)))?;
-
     let mac = _create_request_signature(path, &headers, body_bytes, &key);
     Ok(b64_general_purpose::STANDARD_NO_PAD.encode(mac))
 }


### PR DESCRIPTION
### Purpose
This PR adds the `getExternalMatchBundle` action to allow for parties external to the darkpool to match with parties internal to the darkpool. Internal parties are defined by those that have state committed into the protocol. Because this action interacts with a new server with separate API keys/secrets, the signature of the `postRelayerWithAuth` function was changed to allow for headers and auth key, to be passed in addition to url and body. The other HTTP helpers should follow this change as it is a more reusable abstraction.

### Testing
Tested against testnet stack using local scripts.
- [x] Test against mainnet