### PR TITLE
wasm, core: allow `quote_amount` and `do_gas_estimation` in external order

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.4.3
+
+### Patch Changes
+
+- core: allow `quote_amount` in external order, and `do_gas_estimation`
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/actions/getExternalMatchBundle.ts
+++ b/packages/core/src/actions/getExternalMatchBundle.ts
@@ -18,6 +18,7 @@ export type GetExternalMatchBundleParameters = {
     quoteAmount?: bigint
     minFillSize?: bigint
   }
+  doGasEstimation?: boolean
 }
 
 export type GetExternalMatchBundleReturnType = ExternalMatchBundle
@@ -37,6 +38,7 @@ export async function getExternalMatchBundle(
       quoteAmount = BigInt(0),
       minFillSize = BigInt(0),
     },
+    doGasEstimation = false,
   } = parameters
   const { apiSecret, apiKey } = config
   invariant(apiSecret, 'API secret not specified in config')
@@ -50,6 +52,7 @@ export async function getExternalMatchBundle(
     toHex(baseAmount),
     toHex(quoteAmount),
     toHex(minFillSize),
+    doGasEstimation,
   )
 
   const res = await postWithSymmetricKey(config, {

--- a/packages/core/src/actions/getExternalMatchBundle.ts
+++ b/packages/core/src/actions/getExternalMatchBundle.ts
@@ -10,11 +10,14 @@ import type { ExternalMatchBundle } from '../types/externalOrder.js'
 import { postWithSymmetricKey } from '../utils/http.js'
 
 export type GetExternalMatchBundleParameters = {
-  base: `0x${string}`
-  quote: `0x${string}`
-  side: 'buy' | 'sell'
-  amount: bigint
-  minFillSize?: bigint
+  order: {
+    base: `0x${string}`
+    quote: `0x${string}`
+    side: 'buy' | 'sell'
+    baseAmount?: bigint
+    quoteAmount?: bigint
+    minFillSize?: bigint
+  }
 }
 
 export type GetExternalMatchBundleReturnType = ExternalMatchBundle
@@ -25,7 +28,16 @@ export async function getExternalMatchBundle(
   config: AuthConfig,
   parameters: GetExternalMatchBundleParameters,
 ): Promise<GetExternalMatchBundleReturnType> {
-  const { base, quote, side, amount, minFillSize = BigInt(0) } = parameters
+  const {
+    order: {
+      base,
+      quote,
+      side,
+      baseAmount = BigInt(0),
+      quoteAmount = BigInt(0),
+      minFillSize = BigInt(0),
+    },
+  } = parameters
   const { apiSecret, apiKey } = config
   invariant(apiSecret, 'API secret not specified in config')
   invariant(apiKey, 'API key not specified in config')
@@ -35,7 +47,8 @@ export async function getExternalMatchBundle(
     base,
     quote,
     side,
-    toHex(amount),
+    toHex(baseAmount),
+    toHex(quoteAmount),
     toHex(minFillSize),
   )
 

--- a/packages/core/src/types/externalOrder.ts
+++ b/packages/core/src/types/externalOrder.ts
@@ -14,6 +14,7 @@ export type ExternalSettlementTx = {
   to: `0x${string}`
   data: `0x${string}`
   accessList: AccessList
+  gas?: `0x${string}`
 }
 
 export type ExternalMatchBundle = {

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -95,11 +95,12 @@ export function update_order(seed: string, wallet_str: string, id: string, base_
 * @param {string} base_mint
 * @param {string} quote_mint
 * @param {string} side
-* @param {string} amount
+* @param {string} base_amount
+* @param {string} quote_amount
 * @param {string} min_fill_size
 * @returns {any}
 */
-export function new_external_order(base_mint: string, quote_mint: string, side: string, amount: string, min_fill_size: string): any;
+export function new_external_order(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string): any;
 /**
 * @param {string} path
 * @param {any} headers

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -98,9 +98,10 @@ export function update_order(seed: string, wallet_str: string, id: string, base_
 * @param {string} base_amount
 * @param {string} quote_amount
 * @param {string} min_fill_size
+* @param {boolean} do_gas_estimation
 * @returns {any}
 */
-export function new_external_order(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string): any;
+export function new_external_order(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string, do_gas_estimation: boolean): any;
 /**
 * @param {string} path
 * @param {any} headers

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.3
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.3
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.3.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.3
+
 ## 0.3.2
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -645,8 +645,12 @@ pub struct ExternalOrder {
     pub base_mint: BigUint,
     /// The side of the market this order is on
     pub side: OrderSide,
-    /// The amount of the order
-    pub amount: Amount,
+    /// The base amount of the order
+    #[serde(default, alias = "amount")]
+    pub base_amount: Amount,
+    /// The quote amount of the order
+    #[serde(default)]
+    pub quote_amount: Amount,
     /// The minimum fill size for the order
     #[serde(default)]
     pub min_fill_size: Amount,
@@ -657,7 +661,8 @@ pub fn new_external_order(
     base_mint: &str,
     quote_mint: &str,
     side: &str,
-    amount: &str,
+    base_amount: &str,
+    quote_amount: &str,
     min_fill_size: &str,
 ) -> Result<JsValue, JsError> {
     let side = match side.to_lowercase().as_str() {
@@ -665,7 +670,11 @@ pub fn new_external_order(
         "buy" => OrderSide::Buy,
         _ => return Err(JsError::new("Invalid order side")),
     };
-    let amount = wrap_eyre!(biguint_from_hex_string(amount))
+    let base_amount = wrap_eyre!(biguint_from_hex_string(base_amount))
+        .unwrap()
+        .to_u128()
+        .unwrap();
+    let quote_amount = wrap_eyre!(biguint_from_hex_string(quote_amount))
         .unwrap()
         .to_u128()
         .unwrap();
@@ -678,7 +687,8 @@ pub fn new_external_order(
         base_mint: biguint_from_hex_string(base_mint).unwrap(),
         quote_mint: biguint_from_hex_string(quote_mint).unwrap(),
         side,
-        amount,
+        base_amount,
+        quote_amount,
         min_fill_size,
     };
     let req = ExternalMatchRequest { external_order };

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -624,6 +624,9 @@ pub fn update_order(
 /// The request type for requesting an external match
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExternalMatchRequest {
+    /// Whether or not to include gas estimation in the response
+    #[serde(default)]
+    pub do_gas_estimation: bool,
     /// The external order
     pub external_order: ExternalOrder,
 }
@@ -664,6 +667,7 @@ pub fn new_external_order(
     base_amount: &str,
     quote_amount: &str,
     min_fill_size: &str,
+    do_gas_estimation: bool,
 ) -> Result<JsValue, JsError> {
     let side = match side.to_lowercase().as_str() {
         "sell" => OrderSide::Sell,
@@ -691,6 +695,9 @@ pub fn new_external_order(
         quote_amount,
         min_fill_size,
     };
-    let req = ExternalMatchRequest { external_order };
+    let req = ExternalMatchRequest {
+        do_gas_estimation,
+        external_order,
+    };
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))
 }


### PR DESCRIPTION
This PR allows external orders to be specified according to `quote_amount`, and also setting the `do_gas_estimation` flag to receive gas estimates in the response.. 

Tested that bundles are received against mainnet auth server.