### PR TITLE
core: add fee details to external match bundle response

### DIFF
--- a/packages/core/src/types/externalOrder.ts
+++ b/packages/core/src/types/externalOrder.ts
@@ -1,4 +1,5 @@
 import type { AccessList } from 'viem'
+import type { FeeTake } from './match.js'
 
 export type ExternalMatchResult = {
   quote_mint: `0x${string}`
@@ -20,4 +21,12 @@ export type ExternalSettlementTx = {
 export type ExternalMatchBundle = {
   match_result: ExternalMatchResult
   settlement_tx: ExternalSettlementTx
+  receive: ExternalAssetTransfer
+  send: ExternalAssetTransfer
+  fees: FeeTake
+}
+
+export type ExternalAssetTransfer = {
+  mint: `0x${string}`
+  amount: bigint
 }

--- a/packages/core/src/types/match.ts
+++ b/packages/core/src/types/match.ts
@@ -1,0 +1,6 @@
+export type FeeTake = {
+  /// The fee the relayer takes
+  relayer_fee: bigint
+  /// The fee the protocol takes
+  protocol_fee: bigint
+}


### PR DESCRIPTION
## Purpose
This PR adds fields to the response type of `getExternalMatchBundle` to be aligned with https://github.com/renegade-fi/renegade/pull/846.

## Testing
Tested that each field exists in the response when fetching from testnet relayer.