### PR TITLE
core: actions: Add `getExternalMatchQuote` and `assembleExternalQuote` actions

### DIFF
--- a/packages/core/src/actions/assembleExternalQuote.ts
+++ b/packages/core/src/actions/assembleExternalQuote.ts
@@ -1,0 +1,54 @@
+import invariant from 'tiny-invariant'
+import {
+    ASSEMBLE_EXTERNAL_MATCH_ROUTE,
+    RENEGADE_API_KEY_HEADER,
+} from '../constants.js'
+import type { AuthConfig } from '../createAuthConfig.js'
+import { BaseError, type BaseErrorType } from '../errors/base.js'
+import type { ExternalMatchBundle, SignedExternalMatchQuote } from '../types/externalMatch.js'
+import { postWithSymmetricKey } from '../utils/http.js'
+import { stringifyForWasm } from '../utils/bigJSON.js'
+
+export type AssembleExternalQuoteParameters = {
+    quote: SignedExternalMatchQuote
+    doGasEstimation?: boolean
+}
+
+export type AssembleExternalQuoteReturnType = ExternalMatchBundle
+
+export type AssembleExternalQuoteErrorType = BaseErrorType
+
+export async function assembleExternalQuote(
+    config: AuthConfig,
+    parameters: AssembleExternalQuoteParameters,
+): Promise<AssembleExternalQuoteReturnType> {
+    const {
+        quote,
+        doGasEstimation = false,
+    } = parameters
+    const { apiSecret, apiKey } = config
+    invariant(apiSecret, 'API secret not specified in config')
+    invariant(apiKey, 'API key not specified in config')
+    const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
+
+    console.log('quote', quote)
+    const stringifiedQuote = stringifyForWasm(quote)
+    console.log('stringifiedQuote', stringifiedQuote)
+    const body = config.utils.assemble_external_match(
+        doGasEstimation,
+        stringifiedQuote,
+    )
+
+    const res = await postWithSymmetricKey(config, {
+        url: config.getAuthServerUrl(ASSEMBLE_EXTERNAL_MATCH_ROUTE),
+        body,
+        key: symmetricKey,
+        headers: {
+            [RENEGADE_API_KEY_HEADER]: apiKey,
+        },
+    })
+    if (!res.match_bundle) {
+        throw new BaseError('Failed to assemble external quote')
+    }
+    return res.match_bundle
+}

--- a/packages/core/src/actions/assembleExternalQuote.ts
+++ b/packages/core/src/actions/assembleExternalQuote.ts
@@ -1,17 +1,20 @@
 import invariant from 'tiny-invariant'
 import {
-    ASSEMBLE_EXTERNAL_MATCH_ROUTE,
-    RENEGADE_API_KEY_HEADER,
+  ASSEMBLE_EXTERNAL_MATCH_ROUTE,
+  RENEGADE_API_KEY_HEADER,
 } from '../constants.js'
 import type { AuthConfig } from '../createAuthConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { ExternalMatchBundle, SignedExternalMatchQuote } from '../types/externalMatch.js'
-import { postWithSymmetricKey } from '../utils/http.js'
+import type {
+  ExternalMatchBundle,
+  SignedExternalMatchQuote,
+} from '../types/externalMatch.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
+import { postWithSymmetricKey } from '../utils/http.js'
 
 export type AssembleExternalQuoteParameters = {
-    quote: SignedExternalMatchQuote
-    doGasEstimation?: boolean
+  quote: SignedExternalMatchQuote
+  doGasEstimation?: boolean
 }
 
 export type AssembleExternalQuoteReturnType = ExternalMatchBundle
@@ -19,36 +22,31 @@ export type AssembleExternalQuoteReturnType = ExternalMatchBundle
 export type AssembleExternalQuoteErrorType = BaseErrorType
 
 export async function assembleExternalQuote(
-    config: AuthConfig,
-    parameters: AssembleExternalQuoteParameters,
+  config: AuthConfig,
+  parameters: AssembleExternalQuoteParameters,
 ): Promise<AssembleExternalQuoteReturnType> {
-    const {
-        quote,
-        doGasEstimation = false,
-    } = parameters
-    const { apiSecret, apiKey } = config
-    invariant(apiSecret, 'API secret not specified in config')
-    invariant(apiKey, 'API key not specified in config')
-    const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
+  const { quote, doGasEstimation = false } = parameters
+  const { apiSecret, apiKey } = config
+  invariant(apiSecret, 'API secret not specified in config')
+  invariant(apiKey, 'API key not specified in config')
+  const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
 
-    console.log('quote', quote)
-    const stringifiedQuote = stringifyForWasm(quote)
-    console.log('stringifiedQuote', stringifiedQuote)
-    const body = config.utils.assemble_external_match(
-        doGasEstimation,
-        stringifiedQuote,
-    )
+  const stringifiedQuote = stringifyForWasm(quote)
+  const body = config.utils.assemble_external_match(
+    doGasEstimation,
+    stringifiedQuote,
+  )
 
-    const res = await postWithSymmetricKey(config, {
-        url: config.getAuthServerUrl(ASSEMBLE_EXTERNAL_MATCH_ROUTE),
-        body,
-        key: symmetricKey,
-        headers: {
-            [RENEGADE_API_KEY_HEADER]: apiKey,
-        },
-    })
-    if (!res.match_bundle) {
-        throw new BaseError('Failed to assemble external quote')
-    }
-    return res.match_bundle
+  const res = await postWithSymmetricKey(config, {
+    url: config.getAuthServerUrl(ASSEMBLE_EXTERNAL_MATCH_ROUTE),
+    body,
+    key: symmetricKey,
+    headers: {
+      [RENEGADE_API_KEY_HEADER]: apiKey,
+    },
+  })
+  if (!res.match_bundle) {
+    throw new BaseError('Failed to assemble external quote')
+  }
+  return res.match_bundle
 }

--- a/packages/core/src/actions/getExternalMatchBundle.ts
+++ b/packages/core/src/actions/getExternalMatchBundle.ts
@@ -6,7 +6,7 @@ import {
 } from '../constants.js'
 import type { AuthConfig } from '../createAuthConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { ExternalMatchBundle } from '../types/externalOrder.js'
+import type { ExternalMatchBundle } from '../types/externalMatch.js'
 import { postWithSymmetricKey } from '../utils/http.js'
 
 export type GetExternalMatchBundleParameters = {

--- a/packages/core/src/actions/getExternalMatchQuote.ts
+++ b/packages/core/src/actions/getExternalMatchQuote.ts
@@ -1,17 +1,20 @@
 import invariant from 'tiny-invariant'
 import { toHex } from 'viem'
 import {
-    RENEGADE_API_KEY_HEADER,
-    REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE,
+  RENEGADE_API_KEY_HEADER,
+  REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE,
 } from '../constants.js'
 import type { AuthConfig } from '../createAuthConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { ExternalOrder, SignedExternalMatchQuote } from '../types/externalMatch.js'
+import type {
+  ExternalOrder,
+  SignedExternalMatchQuote,
+} from '../types/externalMatch.js'
 import { postWithSymmetricKey } from '../utils/http.js'
 
 export type GetExternalMatchQuoteParameters = {
-    order: ExternalOrder
-    doGasEstimation?: boolean
+  order: ExternalOrder
+  doGasEstimation?: boolean
 }
 
 export type GetExternalMatchQuoteReturnType = SignedExternalMatchQuote
@@ -19,47 +22,46 @@ export type GetExternalMatchQuoteReturnType = SignedExternalMatchQuote
 export type GetExternalMatchQuoteErrorType = BaseErrorType
 
 export async function getExternalMatchQuote(
-    config: AuthConfig,
-    parameters: GetExternalMatchQuoteParameters,
+  config: AuthConfig,
+  parameters: GetExternalMatchQuoteParameters,
 ): Promise<GetExternalMatchQuoteReturnType> {
-    const {
-        order: {
-            base_mint,
-            quote_mint,
-            side,
-            base_amount,
-            quote_amount,
-            min_fill_size,
-        },
-        doGasEstimation = false,
-    } = parameters
-    const { apiSecret, apiKey } = config
-    invariant(apiSecret, 'API secret not specified in config')
-    invariant(apiKey, 'API key not specified in config')
-    const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
+  const {
+    order: {
+      base_mint,
+      quote_mint,
+      side,
+      base_amount,
+      quote_amount,
+      min_fill_size,
+    },
+    doGasEstimation = false,
+  } = parameters
+  const { apiSecret, apiKey } = config
+  invariant(apiSecret, 'API secret not specified in config')
+  invariant(apiKey, 'API key not specified in config')
+  const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
 
-    const body = config.utils.new_external_order(
-        base_mint,
-        quote_mint,
-        side,
-        toHex(base_amount),
-        toHex(quote_amount),
-        toHex(min_fill_size),
-        doGasEstimation,
-    )
+  const body = config.utils.new_external_order(
+    base_mint,
+    quote_mint,
+    side,
+    toHex(base_amount),
+    toHex(quote_amount),
+    toHex(min_fill_size),
+    doGasEstimation,
+  )
 
-    const res = await postWithSymmetricKey(config, {
-        url: config.getAuthServerUrl(REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE),
-        body,
-        key: symmetricKey,
-        headers: {
-            [RENEGADE_API_KEY_HEADER]: apiKey,
-        },
-    })
-    if (!res.signed_quote) {
-        throw new BaseError('No quote found')
-    }
+  const res = await postWithSymmetricKey(config, {
+    url: config.getAuthServerUrl(REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE),
+    body,
+    key: symmetricKey,
+    headers: {
+      [RENEGADE_API_KEY_HEADER]: apiKey,
+    },
+  })
+  if (!res.signed_quote) {
+    throw new BaseError('No quote found')
+  }
 
-    console.log('res', res.signed_quote.quote.match_result)
-    return res.signed_quote
+  return res.signed_quote
 }

--- a/packages/core/src/actions/getExternalMatchQuote.ts
+++ b/packages/core/src/actions/getExternalMatchQuote.ts
@@ -56,8 +56,10 @@ export async function getExternalMatchQuote(
             [RENEGADE_API_KEY_HEADER]: apiKey,
         },
     })
-    if (!res.match_bundle) {
-        throw new BaseError('No match bundle found')
+    if (!res.signed_quote) {
+        throw new BaseError('No quote found')
     }
-    return res.match_bundle
+
+    console.log('res', res.signed_quote.quote.match_result)
+    return res.signed_quote
 }

--- a/packages/core/src/actions/getExternalMatchQuote.ts
+++ b/packages/core/src/actions/getExternalMatchQuote.ts
@@ -1,0 +1,63 @@
+import invariant from 'tiny-invariant'
+import { toHex } from 'viem'
+import {
+    RENEGADE_API_KEY_HEADER,
+    REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE,
+} from '../constants.js'
+import type { AuthConfig } from '../createAuthConfig.js'
+import { BaseError, type BaseErrorType } from '../errors/base.js'
+import type { ExternalOrder, SignedExternalMatchQuote } from '../types/externalMatch.js'
+import { postWithSymmetricKey } from '../utils/http.js'
+
+export type GetExternalMatchQuoteParameters = {
+    order: ExternalOrder
+    doGasEstimation?: boolean
+}
+
+export type GetExternalMatchQuoteReturnType = SignedExternalMatchQuote
+
+export type GetExternalMatchQuoteErrorType = BaseErrorType
+
+export async function getExternalMatchQuote(
+    config: AuthConfig,
+    parameters: GetExternalMatchQuoteParameters,
+): Promise<GetExternalMatchQuoteReturnType> {
+    const {
+        order: {
+            base_mint,
+            quote_mint,
+            side,
+            base_amount,
+            quote_amount,
+            min_fill_size,
+        },
+        doGasEstimation = false,
+    } = parameters
+    const { apiSecret, apiKey } = config
+    invariant(apiSecret, 'API secret not specified in config')
+    invariant(apiKey, 'API key not specified in config')
+    const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
+
+    const body = config.utils.new_external_order(
+        base_mint,
+        quote_mint,
+        side,
+        toHex(base_amount),
+        toHex(quote_amount),
+        toHex(min_fill_size),
+        doGasEstimation,
+    )
+
+    const res = await postWithSymmetricKey(config, {
+        url: config.getAuthServerUrl(REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE),
+        body,
+        key: symmetricKey,
+        headers: {
+            [RENEGADE_API_KEY_HEADER]: apiKey,
+        },
+    })
+    if (!res.match_bundle) {
+        throw new BaseError('No match bundle found')
+    }
+    return res.match_bundle
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -210,8 +210,7 @@ export const REQUEST_EXTERNAL_MATCH_ROUTE =
   '/matching-engine/request-external-match'
 
 /// The route for requesting an external match quote
-export const REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE =
-  '/matching-engine/quote'
+export const REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE = '/matching-engine/quote'
 
 /// The route for assembling an external match
 export const ASSEMBLE_EXTERNAL_MATCH_ROUTE =

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -209,6 +209,14 @@ export const PRICE_REPORTER_ROUTE = (
 export const REQUEST_EXTERNAL_MATCH_ROUTE =
   '/matching-engine/request-external-match'
 
+/// The route for requesting an external match quote
+export const REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE =
+  '/matching-engine/quote'
+
+/// The route for assembling an external match
+export const ASSEMBLE_EXTERNAL_MATCH_ROUTE =
+  '/matching-engine/assemble-external-match'
+
 ////////////////////////////////////////////////////////////////////////////////
 // Token
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -57,6 +57,13 @@ export {
 } from '../actions/getExternalMatchBundle.js'
 
 export {
+  type GetExternalMatchQuoteParameters,
+  type GetExternalMatchQuoteReturnType,
+  type GetExternalMatchQuoteErrorType,
+  getExternalMatchQuote,
+} from '../actions/getExternalMatchQuote.js'
+
+export {
   type GetBalancesReturnType,
   getBalances,
 } from '../actions/getBalances.js'

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -64,6 +64,13 @@ export {
 } from '../actions/getExternalMatchQuote.js'
 
 export {
+  type AssembleExternalQuoteParameters,
+  type AssembleExternalQuoteReturnType,
+  type AssembleExternalQuoteErrorType,
+  assembleExternalQuote,
+} from '../actions/assembleExternalQuote.js'
+
+export {
   type GetBalancesReturnType,
   getBalances,
 } from '../actions/getBalances.js'

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -61,6 +61,20 @@ export {
 } from '../actions/getExternalMatchBundle.js'
 
 export {
+  type GetExternalMatchQuoteParameters,
+  type GetExternalMatchQuoteReturnType,
+  type GetExternalMatchQuoteErrorType,
+  getExternalMatchQuote,
+} from '../actions/getExternalMatchQuote.js'
+
+export {
+  type AssembleExternalQuoteParameters,
+  type AssembleExternalQuoteReturnType,
+  type AssembleExternalQuoteErrorType,
+  assembleExternalQuote,
+} from '../actions/assembleExternalQuote.js'
+
+export {
   type GetBalancesReturnType,
   getBalances,
 } from '../actions/getBalances.js'

--- a/packages/core/src/types/externalMatch.ts
+++ b/packages/core/src/types/externalMatch.ts
@@ -1,5 +1,15 @@
 import type { AccessList } from 'viem'
-import type { FeeTake } from './match.js'
+import type { FeeTake, TimestampedPrice } from './match.js'
+
+/** An external order */
+export type ExternalOrder = {
+  quote_mint: `0x${string}`
+  base_mint: `0x${string}`
+  side: 'buy' | 'sell'
+  base_amount: bigint
+  quote_amount: bigint
+  min_fill_size: bigint
+}
 
 export type ExternalMatchResult = {
   quote_mint: `0x${string}`
@@ -16,6 +26,21 @@ export type ExternalSettlementTx = {
   data: `0x${string}`
   accessList: AccessList
   gas?: `0x${string}`
+}
+
+export type ExternalMatchQuote = {
+  order: ExternalOrder
+  match_result: ExternalMatchResult
+  fees: FeeTake
+  send: ExternalAssetTransfer
+  receive: ExternalAssetTransfer
+  price: TimestampedPrice
+  timestamp: bigint
+}
+
+export type SignedExternalMatchQuote = {
+  quote: ExternalMatchQuote
+  signature: `0x${string}`
 }
 
 export type ExternalMatchBundle = {

--- a/packages/core/src/types/match.ts
+++ b/packages/core/src/types/match.ts
@@ -4,3 +4,9 @@ export type FeeTake = {
   /// The fee the protocol takes
   protocol_fee: bigint
 }
+
+export type TimestampedPrice = {
+  /// The price of the token, represented as a string to avoid floating point precision issues
+  price: string
+  timestamp: bigint
+}

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -103,6 +103,16 @@ export function update_order(seed: string, wallet_str: string, id: string, base_
 */
 export function new_external_order(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string, do_gas_estimation: boolean): any;
 /**
+* @param {string} base_mint
+* @param {string} quote_mint
+* @param {string} side
+* @param {string} base_amount
+* @param {string} quote_amount
+* @param {string} min_fill_size
+* @returns {any}
+*/
+export function new_external_quote_request(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string): any;
+/**
 * @param {string} path
 * @param {any} headers
 * @param {string} body

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -113,18 +113,11 @@ export function new_external_order(base_mint: string, quote_mint: string, side: 
 */
 export function new_external_quote_request(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string): any;
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
+* @param {boolean} do_gas_estimation
+* @param {string} signed_quote
+* @returns {any}
 */
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
+export function assemble_external_match(do_gas_estimation: boolean, signed_quote: string): any;
 /**
 * @param {string} seed
 * @param {bigint} nonce
@@ -148,3 +141,16 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -12,7 +12,10 @@ import { parseBigJSON } from './bigJSON.js'
 
 export async function postRelayerRaw(url: string, body: any, headers = {}) {
   try {
-    const response = await axios.post(url, body, { headers })
+    const response = await axios.post(url, body, {
+      headers,
+      transformResponse: (data) => parseBigJSON(data),
+    })
     // console.log(`POST ${url} with body: `, body, "response: ", response.data)
     // Process the response data as needed
     return response.data // Assuming the function should return the response data

--- a/wasm/src/external_api/auth/auth_helpers.rs
+++ b/wasm/src/external_api/auth/auth_helpers.rs
@@ -1,6 +1,5 @@
 use crate::common::keychain::HmacKey;
 use base64::engine::{general_purpose as b64_general_purpose, Engine};
-use hex;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 

--- a/wasm/src/external_api/types.rs
+++ b/wasm/src/external_api/types.rs
@@ -24,6 +24,8 @@ use crate::{
     types::{biguint_to_scalar, scalar_to_biguint, scalar_to_u64, Scalar},
 };
 
+use super::http::ExternalOrder;
+
 // --------------------
 // | Wallet API Types |
 // --------------------
@@ -309,4 +311,78 @@ impl TryFrom<ApiKeychain> for KeyChain {
             secret_keys: PrivateKeyChain::try_from(keys.private_keys)?,
         })
     }
+}
+
+// ----------------------------
+// | External Match API Types |
+// ----------------------------
+
+/// The fee takes from a match
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub struct FeeTake {
+    /// The fee the relayer takes
+    pub relayer_fee: Amount,
+    /// The fee the protocol takes
+    pub protocol_fee: Amount,
+}
+/// A signed quote for an external order
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SignedExternalQuote {
+    /// The quote
+    pub quote: ApiExternalQuote,
+    /// The signature
+    pub signature: String,
+}
+
+/// A quote for an external order
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ApiExternalQuote {
+    /// The external order
+    pub order: ExternalOrder,
+    /// The match result
+    pub match_result: ApiExternalMatchResult,
+    /// The estimated fees for the match
+    pub fees: FeeTake,
+    /// The amount sent by the external party
+    pub send: ApiExternalAssetTransfer,
+    /// The amount received by the external party, net of fees
+    pub receive: ApiExternalAssetTransfer,
+    /// The price of the match
+    pub price: ApiTimestampedPrice,
+    /// The timestamp of the quote
+    pub timestamp: u64,
+}
+
+/// An API server external match result
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiExternalMatchResult {
+    /// The mint of the quote token in the matched asset pair
+    pub quote_mint: String,
+    /// The mint of the base token in the matched asset pair
+    pub base_mint: String,
+    /// The amount of the quote token exchanged by the match
+    pub quote_amount: Amount,
+    /// The amount of the base token exchanged by the match
+    pub base_amount: Amount,
+    /// The direction of the match
+    pub direction: OrderSide,
+}
+
+/// An asset transfer from an external party
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ApiExternalAssetTransfer {
+    /// The mint of the asset
+    pub mint: String,
+    /// The amount of the asset
+    pub amount: Amount,
+}
+
+/// The price of a quote
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ApiTimestampedPrice {
+    /// The price, serialized as a string to prevent floating point precision
+    /// issues
+    pub price: String,
+    /// The timestamp, in milliseconds since the epoch
+    pub timestamp: u64,
 }

--- a/wasm/src/external_api/types.rs
+++ b/wasm/src/external_api/types.rs
@@ -318,7 +318,7 @@ impl TryFrom<ApiKeychain> for KeyChain {
 // ----------------------------
 
 /// The fee takes from a match
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct FeeTake {
     /// The fee the relayer takes
     pub relayer_fee: Amount,
@@ -326,7 +326,7 @@ pub struct FeeTake {
     pub protocol_fee: Amount,
 }
 /// A signed quote for an external order
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignedExternalQuote {
     /// The quote
     pub quote: ApiExternalQuote,
@@ -335,7 +335,7 @@ pub struct SignedExternalQuote {
 }
 
 /// A quote for an external order
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiExternalQuote {
     /// The external order
     pub order: ExternalOrder,
@@ -369,7 +369,7 @@ pub struct ApiExternalMatchResult {
 }
 
 /// An asset transfer from an external party
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiExternalAssetTransfer {
     /// The mint of the asset
     pub mint: String,
@@ -378,7 +378,7 @@ pub struct ApiExternalAssetTransfer {
 }
 
 /// The price of a quote
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiTimestampedPrice {
     /// The price, serialized as a string to prevent floating point precision
     /// issues

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -57,7 +57,7 @@ pub fn derive_sk_root_from_seed(seed: &str, nonce: u64) -> JsValue {
 
 #[wasm_bindgen]
 pub fn get_pk_root(seed: &str, nonce: u64) -> JsValue {
-    let sk_root = derive_sk_root_signing_key(&seed, Some(&Scalar::from(nonce))).unwrap();
+    let sk_root = derive_sk_root_signing_key(seed, Some(&Scalar::from(nonce))).unwrap();
     let keychain = wrap_eyre!(derive_wallet_keychain(&sk_root)).unwrap();
     let pk_root = public_sign_key_to_hex_string(&keychain.public_keys.pk_root);
     JsValue::from_str(&pk_root)
@@ -65,7 +65,7 @@ pub fn get_pk_root(seed: &str, nonce: u64) -> JsValue {
 
 #[wasm_bindgen]
 pub fn get_pk_root_scalars(seed: &str, nonce: u64) -> Vec<JsValue> {
-    let sk_root = derive_sk_root_signing_key(&seed, Some(&Scalar::from(nonce))).unwrap();
+    let sk_root = derive_sk_root_signing_key(seed, Some(&Scalar::from(nonce))).unwrap();
     let keychain = wrap_eyre!(derive_wallet_keychain(&sk_root)).unwrap();
     keychain
         .public_keys
@@ -78,7 +78,7 @@ pub fn get_pk_root_scalars(seed: &str, nonce: u64) -> Vec<JsValue> {
 #[wasm_bindgen]
 pub fn get_symmetric_key(seed: &str) -> JsValue {
     utils::set_panic_hook();
-    let sk_root = derive_sk_root_signing_key(&seed, None).unwrap();
+    let sk_root = derive_sk_root_signing_key(seed, None).unwrap();
     let symmetric_key = derive_symmetric_key(&sk_root);
 
     JsValue::from_str(&symmetric_key.unwrap().to_hex_string())


### PR DESCRIPTION
### Purpose
This PR adds two actions for:
- Fetching an external match quote from the relayer
- Assembling this external match quote into a settlement bundle

As well, this PR fixes an issue deserializing bigints in POST requests in an analogous way to the fix for GET requests.

### Testing
-[x] I tested this flow locally using a typescript client I wrote