### PR TITLE
core: actions: getExternalMatchQuote: Use consistent parameter names

### DIFF
--- a/packages/core/src/actions/getExternalMatchBundle.ts
+++ b/packages/core/src/actions/getExternalMatchBundle.ts
@@ -6,18 +6,14 @@ import {
 } from '../constants.js'
 import type { AuthConfig } from '../createAuthConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { ExternalMatchBundle } from '../types/externalMatch.js'
+import type {
+  ExternalMatchBundle,
+  ExternalOrder,
+} from '../types/externalMatch.js'
 import { postWithSymmetricKey } from '../utils/http.js'
 
 export type GetExternalMatchBundleParameters = {
-  order: {
-    base: `0x${string}`
-    quote: `0x${string}`
-    side: 'buy' | 'sell'
-    baseAmount?: bigint
-    quoteAmount?: bigint
-    minFillSize?: bigint
-  }
+  order: ExternalOrder
   doGasEstimation?: boolean
 }
 

--- a/packages/core/src/actions/getExternalMatchQuote.ts
+++ b/packages/core/src/actions/getExternalMatchQuote.ts
@@ -27,12 +27,12 @@ export async function getExternalMatchQuote(
 ): Promise<GetExternalMatchQuoteReturnType> {
   const {
     order: {
-      base_mint,
-      quote_mint,
+      base,
+      quote,
       side,
-      base_amount,
-      quote_amount,
-      min_fill_size,
+      baseAmount = BigInt(0),
+      quoteAmount = BigInt(0),
+      minFillSize = BigInt(0),
     },
     doGasEstimation = false,
   } = parameters
@@ -42,12 +42,12 @@ export async function getExternalMatchQuote(
   const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
 
   const body = config.utils.new_external_order(
-    base_mint,
-    quote_mint,
+    base,
+    quote,
     side,
-    toHex(base_amount),
-    toHex(quote_amount),
-    toHex(min_fill_size),
+    toHex(baseAmount),
+    toHex(quoteAmount),
+    toHex(minFillSize),
     doGasEstimation,
   )
 

--- a/packages/core/src/types/externalMatch.ts
+++ b/packages/core/src/types/externalMatch.ts
@@ -3,12 +3,12 @@ import type { FeeTake, TimestampedPrice } from './match.js'
 
 /** An external order */
 export type ExternalOrder = {
-  quote_mint: `0x${string}`
-  base_mint: `0x${string}`
+  base: `0x${string}`
+  quote: `0x${string}`
   side: 'buy' | 'sell'
-  base_amount: bigint
-  quote_amount: bigint
-  min_fill_size: bigint
+  baseAmount?: bigint
+  quoteAmount?: bigint
+  minFillSize?: bigint
 }
 
 export type ExternalMatchResult = {


### PR DESCRIPTION
### Purpose
This PR makes the naming in `getExternalMatchQuote` consistent with `getExternalMatchBundle`.

### Testing
- [x] Tested with a local client