### PR TITLE
packages: Bump version to 0.4.6 for `node` and `core`

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.4.6
+
+### Patch Changes
+
+- Use consistent naming in `getExternalMatchQuote`
+
 ## 0.4.5
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.4.6
+
+### Patch Changes
+
+- Use consistent naming in `getExternalMatchQuote`
+- Updated dependencies
+  - @renegade-fi/core@0.4.6
+
 ## 0.4.5
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.4.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.6
+
 ## 0.4.6
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.3.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.6
+
 ## 0.3.5
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
### Purpose
This PR bumps the versions for the `node` and `core` packages.