### PR TITLE
core: token: fetch token mapping, use new format

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,3 @@
-import invariant from 'tiny-invariant'
 import type { Address } from 'viem'
 
 /// Header name for the HTTP auth signature
@@ -215,23 +214,3 @@ export const REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE = '/matching-engine/quote'
 /// The route for assembling an external match
 export const ASSEMBLE_EXTERNAL_MATCH_ROUTE =
   '/matching-engine/assemble-external-match'
-
-////////////////////////////////////////////////////////////////////////////////
-// Token
-////////////////////////////////////////////////////////////////////////////////
-
-invariant(
-  process.env.NEXT_PUBLIC_TOKEN_MAPPING || process.env.TOKEN_MAPPING,
-  'TOKEN_MAPPING is not set',
-)
-
-export const tokenMapping = JSON.parse(
-  process.env.NEXT_PUBLIC_TOKEN_MAPPING ?? process.env.TOKEN_MAPPING ?? '{}',
-) as {
-  tokens: Array<{
-    name: string
-    ticker: string
-    address: Address
-    decimals: number
-  }>
-}

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -276,7 +276,10 @@ export { BaseError } from '../errors/base.js'
 // Types
 ////////////////////////////////////////////////////////////////////////////////
 
-export { Token } from '../types/token.js'
+export {
+  Token,
+  tokenMapping,
+} from '../types/token.js'
 export * from '../types/wallet.js'
 export * from '../types/order.js'
 export * from '../types/task.js'

--- a/packages/core/src/types/token.ts
+++ b/packages/core/src/types/token.ts
@@ -1,5 +1,44 @@
+import invariant from 'tiny-invariant'
 import { type Address, isHex, zeroAddress } from 'viem'
-import { tokenMapping } from '../constants.js'
+
+////////////////////////////////////////////////////////////////////////////////
+// Token Mapping
+////////////////////////////////////////////////////////////////////////////////
+
+type SupportedExchange = 'Binance' | 'Coinbase' | 'Kraken' | 'Okx'
+
+type TokenMapping = {
+  tokens: Array<{
+    name: string
+    ticker: string
+    address: Address
+    decimals: number
+    supported_exchanges: Record<SupportedExchange, string>
+    chain_addresses: Record<string, string>
+    logo_url: string
+  }>
+}
+
+const tokenMappingUrl =
+  process.env.TOKEN_MAPPING_URL || process.env.NEXT_PUBIC_TOKEN_MAPPING_URL
+
+const tokenMappingStr =
+  process.env.NEXT_PUBLIC_TOKEN_MAPPING || process.env.TOKEN_MAPPING
+
+invariant(
+  tokenMappingUrl || tokenMappingStr,
+  'No token mapping initialization option provided',
+)
+
+export const tokenMapping = JSON.parse(
+  tokenMappingUrl
+    ? await fetch(tokenMappingUrl).then((res) => res.json())
+    : tokenMappingStr!,
+) as TokenMapping
+
+////////////////////////////////////////////////////////////////////////////////
+// Token Class
+////////////////////////////////////////////////////////////////////////////////
 
 export class Token {
   private _name: string

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.7",
+  "version": "0.0.0-canary-20241204012905",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -242,10 +242,12 @@ export {
   // Types
   OrderState,
   TaskType,
-  Token,
   UpdateType,
   // WebSocket
   AuthType,
   RelayerWebsocket,
   type RelayerWebsocketParams,
+  // Token
+  Token,
+  tokenMapping,
 } from '@renegade-fi/core'


### PR DESCRIPTION
This PR updates the initialization of the `tokenMapping` constant and the properties of `Token` class.

Namely, the SDK now checks for the presence of a `TOKEN_MAPPING_URL` or `NEXT_PUBLIC_TOKEN_MAPPING_URL` environment variable, which, if present, results in the token mapping being fetched from the given URL.

The new token mapping fields - `supported_exchanges`, `chain_addresses`, and `logo_url` - have been added to the `Token` class, along with expected getters.