### PR TITLE
core: token: export loadTokenMapping function

### DIFF
--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -279,6 +279,7 @@ export { BaseError } from '../errors/base.js'
 export {
   Token,
   tokenMapping,
+  loadTokenMapping,
   DEFAULT_QUOTE,
 } from '../types/token.js'
 export * from '../types/wallet.js'

--- a/packages/core/src/types/token.ts
+++ b/packages/core/src/types/token.ts
@@ -31,22 +31,36 @@ invariant(
   'No token mapping initialization option provided',
 )
 
-export const tokenMapping: TokenMapping = tokenMappingUrl
-  ? await fetch(tokenMappingUrl)
-      .then((res) => res.json())
-      .then((data) => {
-        for (const t of data.tokens) {
-          t.supported_exchanges = Object.fromEntries(
-            Object.entries(t.supported_exchanges).map(([k, v]) => [
-              // Lowercase all of the exchange names to match the Exchange enum
-              k.toLowerCase(),
-              v,
-            ]),
-          )
-        }
-        return data
-      })
-  : JSON.parse(tokenMappingStr!)
+export const tokenMapping: TokenMapping = {
+  tokens: [],
+}
+
+export async function loadTokenMapping() {
+  if (!tokenMappingUrl) {
+    throw new Error('No token mapping URL provided')
+  }
+
+  const res = await fetch(tokenMappingUrl)
+  const data = await res.json()
+  for (const t of data.tokens) {
+    t.supported_exchanges = Object.fromEntries(
+      Object.entries(t.supported_exchanges).map(([k, v]) => [
+        // Lowercase all of the exchange names to match the Exchange enum
+        k.toLowerCase(),
+        v,
+      ]),
+    )
+  }
+
+  tokenMapping.tokens = data.tokens
+}
+
+if (tokenMappingUrl) {
+  await loadTokenMapping()
+} else {
+  const envTokenMapping = JSON.parse(tokenMappingStr!)
+  tokenMapping.tokens = envTokenMapping.tokens
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Token Class

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -250,5 +250,6 @@ export {
   // Token
   Token,
   tokenMapping,
+  loadTokenMapping,
   DEFAULT_QUOTE,
 } from '@renegade-fi/core'


### PR DESCRIPTION
This PR packages the fetching & setting of the token mapping into a `loadTokenMapping` function that is exported, in case any clients want to refetch / reset the token mapping. This has been tested by running a simple node server that loads (and reloads) the token mapping after a change.