### PR TITLE
core: token: no top-level fetch

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.4.9
+
+### Patch Changes
+
+- defer token mapping fetch to consumer
+
 ## 0.4.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/types/token.ts
+++ b/packages/core/src/types/token.ts
@@ -55,9 +55,7 @@ export async function loadTokenMapping() {
   tokenMapping.tokens = data.tokens
 }
 
-if (tokenMappingUrl) {
-  await loadTokenMapping()
-} else {
+if (tokenMappingStr) {
   const envTokenMapping = JSON.parse(tokenMappingStr!)
   tokenMapping.tokens = envTokenMapping.tokens
 }
@@ -128,6 +126,10 @@ export class Token {
   }
 
   static findByTicker(ticker: string): Token {
+    if (tokenMapping.tokens.length === 0) {
+      throw new Error('Token mapping not initialized')
+    }
+
     const tokenData = tokenMapping.tokens.find(
       (token) => token.ticker === ticker,
     )
@@ -138,6 +140,10 @@ export class Token {
   }
 
   static findByAddress(address: Address): Token {
+    if (tokenMapping.tokens.length === 0) {
+      throw new Error('Token mapping not initialized')
+    }
+
     const tokenData = tokenMapping.tokens.find(
       (token) => token.address.toLowerCase() === address.toLowerCase(),
     )

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.4.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.9
+
 ## 0.4.8
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.9
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.3.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.9
+
 ## 0.3.7
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
This PR removes the top-level `await` from the token module, deferring the fetching of the token mapping to the consumer to prevent incompatibilities with top-level `await`s.