### PR TITLE
core: token: format token mapping when reading from env var

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.4.10
+
+### Patch Changes
+
+- format token mapping from env var
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/types/token.ts
+++ b/packages/core/src/types/token.ts
@@ -42,6 +42,12 @@ export async function loadTokenMapping() {
 
   const res = await fetch(tokenMappingUrl)
   const data = await res.json()
+  formatTokenMapping(data)
+
+  tokenMapping.tokens = data.tokens
+}
+
+function formatTokenMapping(data: any) {
   for (const t of data.tokens) {
     t.supported_exchanges = Object.fromEntries(
       Object.entries(t.supported_exchanges).map(([k, v]) => [
@@ -51,12 +57,11 @@ export async function loadTokenMapping() {
       ]),
     )
   }
-
-  tokenMapping.tokens = data.tokens
 }
 
 if (tokenMappingStr) {
   const envTokenMapping = JSON.parse(tokenMappingStr!)
+  formatTokenMapping(envTokenMapping)
   tokenMapping.tokens = envTokenMapping.tokens
 }
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.10
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.4.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.10
+
 ## 0.4.10
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.3.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.10
+
 ## 0.3.8
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
This PR fixes a bug wherein the token mapping is not formatted when reading it from an environment variable.