### PR TITLE
packages: actions: assembleExternalQuote: Allow updated order

### DIFF
--- a/packages/core/src/actions/assembleExternalQuote.ts
+++ b/packages/core/src/actions/assembleExternalQuote.ts
@@ -7,6 +7,7 @@ import type { AuthConfig } from '../createAuthConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
 import type {
   ExternalMatchBundle,
+  ExternalOrder,
   SignedExternalMatchQuote,
 } from '../types/externalMatch.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
@@ -14,6 +15,7 @@ import { postWithSymmetricKey } from '../utils/http.js'
 
 export type AssembleExternalQuoteParameters = {
   quote: SignedExternalMatchQuote
+  updatedOrder?: ExternalOrder
   doGasEstimation?: boolean
 }
 
@@ -25,15 +27,17 @@ export async function assembleExternalQuote(
   config: AuthConfig,
   parameters: AssembleExternalQuoteParameters,
 ): Promise<AssembleExternalQuoteReturnType> {
-  const { quote, doGasEstimation = false } = parameters
+  const { quote, updatedOrder, doGasEstimation = false } = parameters
   const { apiSecret, apiKey } = config
   invariant(apiSecret, 'API secret not specified in config')
   invariant(apiKey, 'API key not specified in config')
   const symmetricKey = config.utils.b64_to_hex_hmac_key(apiSecret)
 
   const stringifiedQuote = stringifyForWasm(quote)
+  const stringifiedOrder = updatedOrder ? stringifyForWasm(updatedOrder) : ''
   const body = config.utils.assemble_external_match(
     doGasEstimation,
+    stringifiedOrder,
     stringifiedQuote,
   )
 

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -114,10 +114,11 @@ export function new_external_order(base_mint: string, quote_mint: string, side: 
 export function new_external_quote_request(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string): any;
 /**
 * @param {boolean} do_gas_estimation
+* @param {string} updated_order
 * @param {string} signed_quote
 * @returns {any}
 */
-export function assemble_external_match(do_gas_estimation: boolean, signed_quote: string): any;
+export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
 * @param {string} seed
 * @param {bigint} nonce

--- a/wasm/src/circuit_types/order.rs
+++ b/wasm/src/circuit_types/order.rs
@@ -83,13 +83,27 @@ impl Order {
 }
 
 /// The side of the market a given order is on
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize)]
 pub enum OrderSide {
     /// Buy side
     #[default]
     Buy = 0,
     /// Sell side
     Sell,
+}
+
+impl<'de> Deserialize<'de> for OrderSide {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "buy" => Ok(OrderSide::Buy),
+            "sell" => Ok(OrderSide::Sell),
+            _ => Err(serde::de::Error::custom(format!("Invalid order side: {s}"))),
+        }
+    }
 }
 
 impl OrderSide {


### PR DESCRIPTION
### Purpose
This PR allows for an order to update in between quote and assembly. The only fields allowed to update are `baseAmount`, `quoteAmount`, and `minFillSize`.

### Testing
- [x] Tested with a typescript solver client running locally