### PR TITLE
core: add symmetric key getter to config

### DIFF
--- a/packages/core/src/createAuthConfig.ts
+++ b/packages/core/src/createAuthConfig.ts
@@ -1,6 +1,7 @@
 import invariant from 'tiny-invariant'
 import type { BaseConfig } from './createConfig.js'
 import type * as rustUtils from './utils.d.ts'
+import type { Hex } from 'viem'
 
 export type CreateAuthConfigParameters = {
   apiKey: string
@@ -35,6 +36,10 @@ export function createAuthConfig(
     },
     getWebsocketBaseUrl: () => {
       throw new Error('Not implemented')
+    },
+    getSymmetricKey: () => {
+      invariant(parameters.utils, 'Utils are required')
+      return parameters.utils.b64_to_hex_hmac_key(apiSecret) as Hex
     },
   }
 }

--- a/packages/core/src/createExternalKeyConfig.ts
+++ b/packages/core/src/createExternalKeyConfig.ts
@@ -52,6 +52,9 @@ export function createExternalKeyConfig(
     walletId,
     publicKey,
     // BaseConfig
+    utils: parameters.utils,
+    renegadeKeyType: keyTypes.EXTERNAL,
+    relayerUrl,
     getBaseUrl: (route = '') => {
       const formattedRoute = route.startsWith('/') ? route : `/${route}`
       return `${relayerUrl}/v0${formattedRoute}`
@@ -59,9 +62,9 @@ export function createExternalKeyConfig(
     getWebsocketBaseUrl: () => {
       return websocketUrl.replace(/\/$/, '')
     },
-    utils: parameters.utils,
-    renegadeKeyType: keyTypes.EXTERNAL,
-    relayerUrl,
+    getSymmetricKey: () => {
+      return symmetricKey
+    },
   }
 }
 

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -9,6 +9,7 @@ import {
 import type { BaseConfig, Config } from '../createConfig.js'
 import { BaseError } from '../errors/base.js'
 import { parseBigJSON } from './bigJSON.js'
+import type { AuthType } from './websocket.js'
 
 export async function postRelayerRaw(url: string, body: any, headers = {}) {
   try {
@@ -108,8 +109,9 @@ export async function postRelayerWithAuth(
   config: Config,
   url: string,
   body?: string,
+  requestType?: AuthType,
 ) {
-  const symmetricKey = getSymmetricKey(config)
+  const symmetricKey = config.getSymmetricKey(requestType)
   invariant(symmetricKey, 'Failed to derive symmetric key')
 
   const path = getPathFromUrl(url)


### PR DESCRIPTION
### Purpose
This PR adds a getter for the symmetric key for a config. This moves the logic for determining what symmetric key to authenticate a request with to the config.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet