### PR TITLE
wasm, core: implement keychain rotation for external key

### DIFF
--- a/packages/core/src/actions/cancelOrder.ts
+++ b/packages/core/src/actions/cancelOrder.ts
@@ -1,4 +1,5 @@
 import invariant from 'tiny-invariant'
+import type { Hex } from 'viem'
 import { CANCEL_ORDER_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import type { BaseErrorType } from '../errors/base.js'
@@ -9,6 +10,7 @@ import { getWalletId } from './getWalletId.js'
 
 export type CancelOrderParameters = {
   id: string
+  newPublicKey?: Hex
 }
 
 export type CancelOrderReturnType = { taskId: string }
@@ -19,18 +21,25 @@ export async function cancelOrder(
   config: Config,
   parameters: CancelOrderParameters,
 ): Promise<CancelOrderReturnType> {
-  const { id } = parameters
+  const { id, newPublicKey } = parameters
   const {
     getBaseUrl,
     utils,
     state: { seed },
+    renegadeKeyType,
   } = config
   invariant(seed, 'Seed is required')
 
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.cancel_order(seed, stringifyForWasm(wallet), id)
+  const body = utils.cancel_order(
+    seed,
+    stringifyForWasm(wallet),
+    id,
+    renegadeKeyType,
+    newPublicKey,
+  )
 
   try {
     const res = await postRelayerWithAuth(

--- a/packages/core/src/actions/createOrder.ts
+++ b/packages/core/src/actions/createOrder.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { type Address, toHex } from 'viem'
+import { type Address, type Hex, toHex } from 'viem'
 import { WALLET_ORDERS_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import type { BaseErrorType } from '../errors/base.js'
@@ -17,6 +17,7 @@ export type CreateOrderParameters = {
   worstCasePrice?: string
   minFillSize?: bigint
   allowExternalMatches?: boolean
+  newPublicKey?: Hex
 }
 
 export type CreateOrderReturnType = { taskId: string }
@@ -36,11 +37,13 @@ export async function createOrder(
     worstCasePrice = '',
     minFillSize = BigInt(0),
     allowExternalMatches = false,
+    newPublicKey,
   } = parameters
   const {
     getBaseUrl,
     utils,
     state: { seed },
+    renegadeKeyType,
   } = config
   invariant(seed, 'Seed is required')
 
@@ -58,6 +61,8 @@ export async function createOrder(
     worstCasePrice,
     toHex(minFillSize),
     allowExternalMatches,
+    renegadeKeyType,
+    newPublicKey,
   )
 
   try {

--- a/packages/core/src/actions/createOrderInMatchingPool.ts
+++ b/packages/core/src/actions/createOrderInMatchingPool.ts
@@ -34,6 +34,7 @@ export async function createOrderInMatchingPool(
     getBaseUrl,
     utils,
     state: { seed },
+    renegadeKeyType,
   } = config
   invariant(seed, 'Seed is required')
 
@@ -52,6 +53,7 @@ export async function createOrderInMatchingPool(
     toHex(minFillSize),
     allowExternalMatches,
     matchingPool,
+    renegadeKeyType,
   )
 
   try {

--- a/packages/core/src/actions/deposit.ts
+++ b/packages/core/src/actions/deposit.ts
@@ -16,6 +16,7 @@ export type DepositParameters = {
   permitNonce: bigint
   permitDeadline: bigint
   permit: `0x${string}`
+  newPublicKey?: string
 }
 
 export type DepositReturnType = Promise<{ taskId: string }>
@@ -26,12 +27,20 @@ export async function deposit(
   config: Config,
   parameters: DepositParameters,
 ): DepositReturnType {
-  const { fromAddr, mint, amount, permitNonce, permitDeadline, permit } =
-    parameters
+  const {
+    fromAddr,
+    mint,
+    amount,
+    permitNonce,
+    permitDeadline,
+    permit,
+    newPublicKey,
+  } = parameters
   const {
     getBaseUrl,
     utils,
     state: { seed },
+    renegadeKeyType,
   } = config
   invariant(seed, 'Seed is required')
 
@@ -51,6 +60,8 @@ export async function deposit(
     toHex(permitNonce),
     toHex(permitDeadline),
     permit,
+    renegadeKeyType,
+    newPublicKey,
   )
 
   try {

--- a/packages/core/src/actions/withdraw.ts
+++ b/packages/core/src/actions/withdraw.ts
@@ -11,6 +11,7 @@ export type WithdrawParameters = {
   mint: Address
   amount: bigint
   destinationAddr: Address
+  newPublicKey?: string
 }
 
 export type WithdrawReturnType = Promise<{ taskId: string }>
@@ -19,11 +20,12 @@ export async function withdraw(
   config: Config,
   parameters: WithdrawParameters,
 ): WithdrawReturnType {
-  const { mint, amount, destinationAddr } = parameters
+  const { mint, amount, destinationAddr, newPublicKey } = parameters
   const {
     getBaseUrl,
     utils,
     state: { seed },
+    renegadeKeyType,
   } = config
   invariant(seed, 'Seed is required')
 
@@ -37,6 +39,8 @@ export async function withdraw(
     mint,
     toHex(amount),
     destinationAddr,
+    renegadeKeyType,
+    newPublicKey,
   )
 
   try {

--- a/packages/core/src/createAuthConfig.ts
+++ b/packages/core/src/createAuthConfig.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import type { BaseConfig } from './createConfig.js'
+import { keyTypes, type BaseConfig } from './createConfig.js'
 import type * as rustUtils from './utils.d.ts'
 import type { Hex } from 'viem'
 
@@ -30,6 +30,7 @@ export function createAuthConfig(
     utils: parameters.utils,
     apiKey,
     apiSecret,
+    renegadeKeyType: keyTypes.NONE,
     getBaseUrl: (route = '') => {
       const formattedRoute = route.startsWith('/') ? route : `/${route}`
       return `${authServerUrl}/v0${formattedRoute}`

--- a/packages/core/src/createAuthConfig.ts
+++ b/packages/core/src/createAuthConfig.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
-import { keyTypes, type BaseConfig } from './createConfig.js'
-import type * as rustUtils from './utils.d.ts'
 import type { Hex } from 'viem'
+import { type BaseConfig, keyTypes } from './createConfig.js'
+import type * as rustUtils from './utils.d.ts'
 
 export type CreateAuthConfigParameters = {
   apiKey: string

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -182,7 +182,7 @@ export function createConfig(parameters: CreateConfigParameters): Config {
 export type BaseConfig = {
   utils: typeof rustUtils
   getWebsocketBaseUrl: () => string
-  renegadeKeyType?: KeyType
+  renegadeKeyType: KeyType
   getBaseUrl: (route?: string) => string
   // TODO: Move admin key to a separate config
   getSymmetricKey: (type?: AuthType) => Hex
@@ -237,6 +237,7 @@ export interface State {
 export const keyTypes = {
   EXTERNAL: 'external',
   INTERNAL: 'internal',
+  NONE: 'none',
 } as const
 
 type KeyType = (typeof keyTypes)[keyof typeof keyTypes]

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -56,9 +56,11 @@ export function withdraw(seed: string, wallet_str: string, mint: string, amount:
 * @param {string} worst_case_price
 * @param {string} min_fill_size
 * @param {boolean} allow_external_matches
+* @param {string} key_type
+* @param {string | undefined} [new_public_key]
 * @returns {any}
 */
-export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean): any;
+export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string): any;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -71,9 +73,11 @@ export function new_order(seed: string, wallet_str: string, id: string, base_min
 * @param {string} min_fill_size
 * @param {boolean} allow_external_matches
 * @param {string} matching_pool
+* @param {string} key_type
+* @param {string | undefined} [new_public_key]
 * @returns {any}
 */
-export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string): any;
+export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string): any;
 /**
 * @param {string} seed
 * @param {string} wallet_str

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -82,9 +82,11 @@ export function new_order_in_matching_pool(seed: string, wallet_str: string, id:
 * @param {string} seed
 * @param {string} wallet_str
 * @param {string} order_id
+* @param {string} key_type
+* @param {string | undefined} [new_public_key]
 * @returns {any}
 */
-export function cancel_order(seed: string, wallet_str: string, order_id: string): any;
+export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string): any;
 /**
 * @param {string} seed
 * @param {string} wallet_str

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -130,19 +130,6 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
-/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -165,3 +152,16 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -29,9 +29,11 @@ export function wallet_id(seed: string): any;
 * @param {string} permit_nonce
 * @param {string} permit_deadline
 * @param {string} permit_signature
+* @param {string} key_type
+* @param {string | undefined} [new_public_key]
 * @returns {any}
 */
-export function deposit(seed: string, wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string): any;
+export function deposit(seed: string, wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string, key_type: string, new_public_key?: string): any;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -120,6 +122,19 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
+/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -142,16 +157,3 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
-/**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -40,9 +40,11 @@ export function deposit(seed: string, wallet_str: string, from_addr: string, min
 * @param {string} mint
 * @param {string} amount
 * @param {string} destination_addr
+* @param {string} key_type
+* @param {string | undefined} [new_public_key]
 * @returns {any}
 */
-export function withdraw(seed: string, wallet_str: string, mint: string, amount: string, destination_addr: string): any;
+export function withdraw(seed: string, wallet_str: string, mint: string, amount: string, destination_addr: string, key_type: string, new_public_key?: string): any;
 /**
 * @param {string} seed
 * @param {string} wallet_str

--- a/wasm/src/common/keychain.rs
+++ b/wasm/src/common/keychain.rs
@@ -153,6 +153,14 @@ impl KeyChain {
         self.secret_keys.symmetric_key
     }
 
+    /// Get the next rotated keychain's public key without modifying the current keychain
+    pub fn get_next_rotated_public_key(&self, seed: &str) -> Result<PublicSigningKey, String> {
+        let next_nonce = self.public_keys.nonce + Scalar::one();
+        let sk_root = derive_sk_root_signing_key(seed, Some(&next_nonce))?;
+        let rotated_keychain = derive_wallet_keychain(&sk_root)?;
+        Ok(rotated_keychain.public_keys.pk_root)
+    }
+
     // Rotate the keychain by incrementing the nonce and re-deriving the keys
     pub fn rotate(&mut self, seed: &str) {
         self.increment_nonce();

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -164,22 +164,13 @@ pub fn deposit(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Get the next public key based on key type
-    let next_public_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet
-                .key_chain
-                .get_next_rotated_public_key(seed)
-                .unwrap(),
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
-    // Handle key rotation if we have a new public key
-    if let Some(next_key) = &next_public_key {
-        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
-    }
+    let next_public_key = wrap_eyre!(handle_key_rotation(
+        &mut new_wallet,
+        seed,
+        key_type,
+        new_public_key
+    ))
+    .unwrap();
 
     // Modify the wallet
     let mint = wrap_eyre!(biguint_from_hex_string(mint)).unwrap();
@@ -247,22 +238,13 @@ pub fn withdraw(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Get the next public key based on key type
-    let next_public_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet
-                .key_chain
-                .get_next_rotated_public_key(seed)
-                .unwrap(),
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
-    // Handle key rotation if we have a new public key
-    if let Some(next_key) = &next_public_key {
-        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
-    }
+    let next_public_key = wrap_eyre!(handle_key_rotation(
+        &mut new_wallet,
+        seed,
+        key_type,
+        new_public_key
+    ))
+    .unwrap();
 
     // Modify the wallet
     let mint = wrap_eyre!(biguint_from_hex_string(mint)).unwrap();
@@ -451,22 +433,13 @@ pub fn create_order_request(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Get the next public key based on key type
-    let next_public_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet
-                .key_chain
-                .get_next_rotated_public_key(seed)
-                .unwrap(),
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
-    // Handle key rotation if we have a new public key
-    if let Some(next_key) = &next_public_key {
-        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
-    }
+    let next_public_key = wrap_eyre!(handle_key_rotation(
+        &mut new_wallet,
+        seed,
+        key_type,
+        new_public_key
+    ))
+    .unwrap();
 
     let order = create_order(
         id,
@@ -584,22 +557,13 @@ pub fn cancel_order(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Get the next public key based on key type
-    let next_public_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet
-                .key_chain
-                .get_next_rotated_public_key(seed)
-                .unwrap(),
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
-    // Handle key rotation if we have a new public key
-    if let Some(next_key) = &next_public_key {
-        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
-    }
+    let next_public_key = wrap_eyre!(handle_key_rotation(
+        &mut new_wallet,
+        seed,
+        key_type,
+        new_public_key
+    ))
+    .unwrap();
 
     let order_id =
         Uuid::parse_str(order_id).map_err(|e| JsError::new(&format!("Invalid UUID: {}", e)))?;

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -164,17 +164,21 @@ pub fn deposit(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Handle key rotation based on key type
-    match key_type {
-        "internal" => {
-            new_wallet.key_chain.rotate(seed);
-        }
-        "external" => {
-            if let Some(new_pk) = &new_public_key {
-                wrap_eyre!(handle_key_rotation(&mut new_wallet, new_pk)).unwrap();
-            }
-        }
+    // Get the next public key based on key type
+    let next_public_key = match key_type {
+        "internal" => Some(public_sign_key_to_hex_string(
+            &new_wallet
+                .key_chain
+                .get_next_rotated_public_key(seed)
+                .unwrap(),
+        )),
+        "external" => new_public_key,
         _ => return Err(JsError::new("Invalid key type")),
+    };
+
+    // Handle key rotation if we have a new public key
+    if let Some(next_key) = &next_public_key {
+        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
     }
 
     // Modify the wallet
@@ -191,18 +195,9 @@ pub fn deposit(
     let comm = new_wallet.get_wallet_share_commitment();
     let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
 
-    // Determine the new root key based on key type
-    let new_root_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet.key_chain.public_keys.pk_root,
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
     let update_auth = WalletUpdateAuthorization {
         statement_sig: sig.to_vec(),
-        new_root_key,
+        new_root_key: next_public_key,
     };
 
     let req = DepositBalanceRequest {
@@ -252,17 +247,21 @@ pub fn withdraw(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Handle key rotation based on key type
-    match key_type {
-        "internal" => {
-            new_wallet.key_chain.rotate(seed);
-        }
-        "external" => {
-            if let Some(new_pk) = &new_public_key {
-                wrap_eyre!(handle_key_rotation(&mut new_wallet, new_pk)).unwrap();
-            }
-        }
+    // Get the next public key based on key type
+    let next_public_key = match key_type {
+        "internal" => Some(public_sign_key_to_hex_string(
+            &new_wallet
+                .key_chain
+                .get_next_rotated_public_key(seed)
+                .unwrap(),
+        )),
+        "external" => new_public_key,
         _ => return Err(JsError::new("Invalid key type")),
+    };
+
+    // Handle key rotation if we have a new public key
+    if let Some(next_key) = &next_public_key {
+        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
     }
 
     // Modify the wallet
@@ -295,18 +294,9 @@ pub fn withdraw(
     let comm = new_wallet.get_wallet_share_commitment();
     let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
 
-    // Determine the new root key based on key type
-    let new_root_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet.key_chain.public_keys.pk_root,
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
     let update_auth = WalletUpdateAuthorization {
         statement_sig: sig.to_vec(),
-        new_root_key,
+        new_root_key: next_public_key,
     };
 
     let sk_root: SigningKey = SigningKey::try_from(&old_sk_root).unwrap();
@@ -461,17 +451,21 @@ pub fn create_order_request(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Handle key rotation based on key type
-    match key_type {
-        "internal" => {
-            new_wallet.key_chain.rotate(seed);
-        }
-        "external" => {
-            if let Some(new_pk) = &new_public_key {
-                wrap_eyre!(handle_key_rotation(&mut new_wallet, new_pk)).unwrap();
-            }
-        }
+    // Get the next public key based on key type
+    let next_public_key = match key_type {
+        "internal" => Some(public_sign_key_to_hex_string(
+            &new_wallet
+                .key_chain
+                .get_next_rotated_public_key(seed)
+                .unwrap(),
+        )),
+        "external" => new_public_key,
         _ => return Err(JsError::new("Invalid key type")),
+    };
+
+    // Handle key rotation if we have a new public key
+    if let Some(next_key) = &next_public_key {
+        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
     }
 
     let order = create_order(
@@ -493,18 +487,9 @@ pub fn create_order_request(
     let comm = new_wallet.get_wallet_share_commitment();
     let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
 
-    // Determine the new root key based on key type
-    let new_root_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet.key_chain.public_keys.pk_root,
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
     let update_auth = WalletUpdateAuthorization {
         statement_sig: sig.to_vec(),
-        new_root_key,
+        new_root_key: next_public_key,
     };
 
     Ok(CreateOrderRequest { order, update_auth })
@@ -599,17 +584,21 @@ pub fn cancel_order(
     let mut new_wallet = deserialize_wallet(wallet_str);
     let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
-    // Handle key rotation based on key type
-    match key_type {
-        "internal" => {
-            new_wallet.key_chain.rotate(seed);
-        }
-        "external" => {
-            if let Some(new_pk) = &new_public_key {
-                wrap_eyre!(handle_key_rotation(&mut new_wallet, new_pk)).unwrap();
-            }
-        }
+    // Get the next public key based on key type
+    let next_public_key = match key_type {
+        "internal" => Some(public_sign_key_to_hex_string(
+            &new_wallet
+                .key_chain
+                .get_next_rotated_public_key(seed)
+                .unwrap(),
+        )),
+        "external" => new_public_key,
         _ => return Err(JsError::new("Invalid key type")),
+    };
+
+    // Handle key rotation if we have a new public key
+    if let Some(next_key) = &next_public_key {
+        wrap_eyre!(handle_key_rotation(&mut new_wallet, next_key)).unwrap();
     }
 
     let order_id =
@@ -627,18 +616,9 @@ pub fn cancel_order(
     let comm = new_wallet.get_wallet_share_commitment();
     let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
 
-    // Determine the new root key based on key type
-    let new_root_key = match key_type {
-        "internal" => Some(public_sign_key_to_hex_string(
-            &new_wallet.key_chain.public_keys.pk_root,
-        )),
-        "external" => new_public_key,
-        _ => return Err(JsError::new("Invalid key type")),
-    };
-
     let update_auth = WalletUpdateAuthorization {
         statement_sig: sig.to_vec(),
-        new_root_key,
+        new_root_key: next_public_key,
     };
 
     let req = CancelOrderRequest { update_auth };

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -171,7 +171,7 @@ pub fn deposit(
         }
         "external" => {
             if let Some(new_pk) = &new_public_key {
-                handle_key_rotation(&mut new_wallet, new_pk).unwrap();
+                wrap_eyre!(handle_key_rotation(&mut new_wallet, new_pk)).unwrap();
             }
         }
         _ => return Err(JsError::new("Invalid key type")),

--- a/wasm/src/key_rotation.rs
+++ b/wasm/src/key_rotation.rs
@@ -1,0 +1,27 @@
+use crate::{
+    circuit_types::keychain::PublicSigningKey, common::types::Wallet,
+    helpers::bytes_from_hex_string,
+};
+
+/// Checks if the wallet's public key has been rotated and handles the rotation if needed.
+///
+/// This function will:
+/// 1. Compare the current public key with the new one
+/// 2. If different, increment the nonce and set the new public key
+///
+/// # Arguments
+/// * `wallet` - The wallet to check for rotation
+/// * `new_public_key` - The new public key in hex format
+pub fn handle_key_rotation(wallet: &mut Wallet, new_public_key: &str) -> Result<(), String> {
+    let new_pk_root = bytes_from_hex_string(new_public_key)
+        .map_err(|e| format!("Invalid public key hex: {}", e))?;
+    let current_pk_root = wallet.key_chain.pk_root().to_uncompressed_bytes();
+
+    if current_pk_root != new_pk_root {
+        wallet.key_chain.increment_nonce();
+        let new_pk_root = PublicSigningKey::from_bytes(&new_pk_root)
+            .map_err(|e| format!("Failed to parse public key: {}", e))?;
+        wallet.key_chain.set_pk_root(new_pk_root);
+    }
+    Ok(())
+}

--- a/wasm/src/key_rotation.rs
+++ b/wasm/src/key_rotation.rs
@@ -1,26 +1,71 @@
 use crate::{
-    circuit_types::keychain::PublicSigningKey, common::types::Wallet,
-    helpers::bytes_from_hex_string,
+    circuit_types::keychain::PublicSigningKey,
+    common::types::Wallet,
+    helpers::{bytes_from_hex_string, public_sign_key_to_hex_string},
 };
 
-/// Checks if the wallet's public key has been rotated and handles the rotation if needed.
+/// Handles wallet key rotation based on key type.
 ///
-/// This function will:
-/// 1. Compare the current public key with the new one
-/// 2. If different, increment the nonce and set the new public key
+/// Internal type always rotates to the next derived key.
+/// External type only rotates if a new key is provided.
 ///
 /// # Arguments
-/// * `wallet` - The wallet to check for rotation
-/// * `new_public_key` - The new public key in hex format
-pub fn handle_key_rotation(wallet: &mut Wallet, new_public_key: &str) -> Result<(), String> {
-    let new_pk_root = bytes_from_hex_string(new_public_key)
-        .map_err(|e| format!("Invalid public key hex: {}", e))?;
+/// * `wallet` - Target wallet
+/// * `seed` - Seed for key derivation
+/// * `key_type` - "internal" or "external"
+/// * `new_public_key` - Optional new key for external type
+///
+/// # Returns
+/// The rotated public key, if any
+pub fn handle_key_rotation(
+    wallet: &mut Wallet,
+    seed: &str,
+    key_type: &str,
+    new_public_key: Option<String>,
+) -> Result<Option<String>, String> {
+    let next_public_key = determine_next_key(wallet, seed, key_type, new_public_key)?;
+
+    // If we have a new key, perform the rotation
+    if let Some(next_key) = &next_public_key {
+        maybe_rotate_to_key(wallet, next_key)?;
+    }
+
+    Ok(next_public_key)
+}
+
+/// Gets the next public key based on key type.
+fn determine_next_key(
+    wallet: &Wallet,
+    seed: &str,
+    key_type: &str,
+    new_public_key: Option<String>,
+) -> Result<Option<String>, String> {
+    match key_type {
+        "internal" => {
+            // For internal type, derive the next key in sequence
+            let next_key = wallet.key_chain.get_next_rotated_public_key(seed)?;
+            Ok(Some(public_sign_key_to_hex_string(&next_key)))
+        }
+        "external" => Ok(new_public_key),
+        _ => Err("Invalid key type".to_string()),
+    }
+}
+
+/// Updates wallet's key if different from current.
+fn maybe_rotate_to_key(wallet: &mut Wallet, new_key_hex: &str) -> Result<(), String> {
+    // Parse and validate the new key
+    let new_pk_root =
+        bytes_from_hex_string(new_key_hex).map_err(|e| format!("Invalid public key hex: {}", e))?;
     let current_pk_root = wallet.key_chain.pk_root().to_uncompressed_bytes();
 
+    // Only rotate if the key is actually different
     if current_pk_root != new_pk_root {
-        wallet.key_chain.increment_nonce();
+        // Convert bytes to public key
         let new_pk_root = PublicSigningKey::from_bytes(&new_pk_root)
             .map_err(|e| format!("Failed to parse public key: {}", e))?;
+
+        // Update the wallet's key
+        wallet.key_chain.increment_nonce();
         wallet.key_chain.set_pk_root(new_pk_root);
     }
     Ok(())

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -22,6 +22,7 @@ pub mod common;
 pub mod errors;
 pub mod external_api;
 pub mod helpers;
+pub mod key_rotation;
 pub mod serde_def_types;
 pub mod types;
 pub mod utils;


### PR DESCRIPTION
### Purpose
This PR implements keychain rotation for externally managed keys. It uses the Renegade key type to decide whether to rotate the key internally or use the public key provided by the SDK consumer. In both cases, it will increment the nonce if the public key has been rotated.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet