### PR TITLE
wasm, core: impl external key deposit action

### DIFF
--- a/packages/core/src/actions/cancelOrder.ts
+++ b/packages/core/src/actions/cancelOrder.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
 import type { Hex } from 'viem'
 import { CANCEL_ORDER_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { RenegadeConfig } from '../createConfig.js'
 import type { BaseErrorType } from '../errors/base.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
 import { postRelayerWithAuth } from '../utils/http.js'
@@ -18,27 +18,37 @@ export type CancelOrderReturnType = { taskId: string }
 export type CancelOrderErrorType = BaseErrorType
 
 export async function cancelOrder(
-  config: Config,
+  config: RenegadeConfig,
   parameters: CancelOrderParameters,
 ): Promise<CancelOrderReturnType> {
   const { id, newPublicKey } = parameters
-  const {
-    getBaseUrl,
-    utils,
-    state: { seed },
-    renegadeKeyType,
-  } = config
-  invariant(seed, 'Seed is required')
+  const { getBaseUrl, utils, renegadeKeyType } = config
 
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.cancel_order(
-    seed,
+  const seed = renegadeKeyType === 'internal' ? config.state.seed : undefined
+  const signMessage =
+    renegadeKeyType === 'external' ? config.signMessage : undefined
+
+  if (renegadeKeyType === 'external') {
+    invariant(
+      signMessage !== undefined,
+      'Sign message function is required for external key type',
+    )
+  }
+  if (renegadeKeyType === 'internal') {
+    invariant(seed !== undefined, 'Seed is required for internal key type')
+  }
+
+  const body = await utils.cancel_order(
+    // TODO: Change Rust to accept Option<String>
+    seed ?? '',
     stringifyForWasm(wallet),
     id,
     renegadeKeyType,
     newPublicKey,
+    signMessage,
   )
 
   try {

--- a/packages/core/src/actions/createOrderInMatchingPool.ts
+++ b/packages/core/src/actions/createOrderInMatchingPool.ts
@@ -41,7 +41,7 @@ export async function createOrderInMatchingPool(
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.new_order_in_matching_pool(
+  const body = await utils.new_order_in_matching_pool(
     seed,
     stringifyForWasm(wallet),
     id,

--- a/packages/core/src/actions/deposit.ts
+++ b/packages/core/src/actions/deposit.ts
@@ -1,59 +1,50 @@
-import invariant from 'tiny-invariant'
 import { type Address, toHex } from 'viem'
 import { DEPOSIT_BALANCE_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
-import type { BaseErrorType } from '../errors/base.js'
-import { Token } from '../types/token.js'
+import type { RenegadeConfig } from '../createConfig.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
 import { postRelayerWithAuth } from '../utils/http.js'
 import { getBackOfQueueWallet } from './getBackOfQueueWallet.js'
 import { getWalletId } from './getWalletId.js'
 
 export type DepositParameters = {
+  amount: bigint
   fromAddr: Address
   mint: Address
-  amount: bigint
-  permitNonce: bigint
-  permitDeadline: bigint
-  permit: `0x${string}`
   newPublicKey?: string
+  permit: string
+  permitDeadline: bigint
+  permitNonce: bigint
 }
 
 export type DepositReturnType = Promise<{ taskId: string }>
 
-export type DepositErrorType = BaseErrorType
-
 export async function deposit(
-  config: Config,
+  config: RenegadeConfig,
   parameters: DepositParameters,
 ): DepositReturnType {
   const {
+    amount,
     fromAddr,
     mint,
-    amount,
-    permitNonce,
-    permitDeadline,
-    permit,
     newPublicKey,
+    permit,
+    permitDeadline,
+    permitNonce,
   } = parameters
-  const {
-    getBaseUrl,
-    utils,
-    state: { seed },
-    renegadeKeyType,
-  } = config
-  invariant(seed, 'Seed is required')
 
-  const token = Token.findByAddress(mint)
-  invariant(token, 'Token not found')
+  const { getBaseUrl, utils, renegadeKeyType } = config
 
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
-  const walletStr = stringifyForWasm(wallet)
 
-  const body = utils.deposit(
-    seed,
-    walletStr,
+  const seed = renegadeKeyType === 'internal' ? config.state.seed : undefined
+  const signMessage =
+    renegadeKeyType === 'external' ? config.signMessage : undefined
+
+  const body = await utils.deposit(
+    // TODO: Change Rust to accept Option<String>
+    seed ?? '',
+    stringifyForWasm(wallet),
     fromAddr,
     mint,
     toHex(amount),
@@ -62,6 +53,7 @@ export async function deposit(
     permit,
     renegadeKeyType,
     newPublicKey,
+    signMessage,
   )
 
   try {

--- a/packages/core/src/actions/getBackOfQueueWallet.ts
+++ b/packages/core/src/actions/getBackOfQueueWallet.ts
@@ -1,5 +1,5 @@
 import { BACK_OF_QUEUE_WALLET_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { RenegadeConfig } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
 import type { Order } from '../types/order.js'
 import type { Balance, Wallet } from '../types/wallet.js'
@@ -15,7 +15,7 @@ export type GetBackOfQueueWalletReturnType = Wallet
 export type GetBackOfQueueWalletErrorType = BaseErrorType
 
 export async function getBackOfQueueWallet(
-  config: Config,
+  config: RenegadeConfig,
   parameters: GetBackOfQueueWalletParameters = {},
 ): Promise<GetBackOfQueueWalletReturnType> {
   const { filterDefaults } = parameters

--- a/packages/core/src/actions/getWalletId.ts
+++ b/packages/core/src/actions/getWalletId.ts
@@ -1,9 +1,12 @@
 import invariant from 'tiny-invariant'
-import type { Config } from '../createConfig.js'
+import type { RenegadeConfig } from '../createConfig.js'
 
 export type GetWalletIdReturnType = string
 
-export function getWalletId(config: Config): GetWalletIdReturnType {
+export function getWalletId(config: RenegadeConfig): GetWalletIdReturnType {
+  if (config.renegadeKeyType === 'external') {
+    return config.walletId
+  }
   const {
     utils,
     state: { seed },

--- a/packages/core/src/createAuthConfig.ts
+++ b/packages/core/src/createAuthConfig.ts
@@ -1,6 +1,6 @@
 import invariant from 'tiny-invariant'
 import type { Hex } from 'viem'
-import { type BaseConfig, keyTypes } from './createConfig.js'
+import type { BaseConfig } from './createConfig.js'
 import type * as rustUtils from './utils.d.ts'
 
 export type CreateAuthConfigParameters = {
@@ -28,9 +28,10 @@ export function createAuthConfig(
   )
   return {
     utils: parameters.utils,
+    // Not used for wallet operations
+    renegadeKeyType: 'none' as const,
     apiKey,
     apiSecret,
-    renegadeKeyType: keyTypes.NONE,
     getBaseUrl: (route = '') => {
       const formattedRoute = route.startsWith('/') ? route : `/${route}`
       return `${authServerUrl}/v0${formattedRoute}`
@@ -49,4 +50,5 @@ export type AuthConfig = BaseConfig & {
   apiSecret: string
   apiKey: string
   getBaseUrl: (route?: string) => string
+  renegadeKeyType: 'none'
 }

--- a/packages/core/src/createExternalKeyConfig.ts
+++ b/packages/core/src/createExternalKeyConfig.ts
@@ -1,6 +1,6 @@
 import invariant from 'tiny-invariant'
 import type { SignMessageReturnType } from 'viem'
-import { type BaseConfig, keyTypes } from './createConfig.js'
+import type { BaseConfig } from './createConfig.js'
 import type * as rustUtils from './utils.d.ts'
 
 export type CreateExternalKeyConfigParameters = {
@@ -32,7 +32,7 @@ export type CreateExternalKeyConfigParameters = {
  */
 export function createExternalKeyConfig(
   parameters: CreateExternalKeyConfigParameters,
-): ExternalKeyConfig {
+): ExternalConfig {
   const {
     relayerUrl,
     signMessage,
@@ -53,7 +53,7 @@ export function createExternalKeyConfig(
     publicKey,
     // BaseConfig
     utils: parameters.utils,
-    renegadeKeyType: keyTypes.EXTERNAL,
+    renegadeKeyType: 'external' as const,
     relayerUrl,
     getBaseUrl: (route = '') => {
       const formattedRoute = route.startsWith('/') ? route : `/${route}`
@@ -68,11 +68,12 @@ export function createExternalKeyConfig(
   }
 }
 
-export type ExternalKeyConfig = BaseConfig & {
+export type ExternalConfig = BaseConfig & {
   relayerUrl: string
   signMessage: (message: string) => Promise<SignMessageReturnType>
   symmetricKey: `0x${string}`
   walletId: string
   publicKey: `0x${string}`
   getBaseUrl: (route?: string) => string
+  renegadeKeyType: 'external'
 }

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -31,9 +31,10 @@ export function wallet_id(seed: string): any;
 * @param {string} permit_signature
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function deposit(seed: string, wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string, key_type: string, new_public_key?: string): any;
+export function deposit(seed: string, wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -130,6 +131,19 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
+/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -152,16 +166,3 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
-/**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -43,9 +43,10 @@ export function deposit(seed: string, wallet_str: string, from_addr: string, min
 * @param {string} destination_addr
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function withdraw(seed: string, wallet_str: string, mint: string, amount: string, destination_addr: string, key_type: string, new_public_key?: string): any;
+export function withdraw(seed: string, wallet_str: string, mint: string, amount: string, destination_addr: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -59,9 +60,10 @@ export function withdraw(seed: string, wallet_str: string, mint: string, amount:
 * @param {boolean} allow_external_matches
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string): any;
+export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -76,18 +78,20 @@ export function new_order(seed: string, wallet_str: string, id: string, base_min
 * @param {string} matching_pool
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string): any;
+export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
 * @param {string} order_id
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string): any;
+export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -131,19 +135,6 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
-/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -166,3 +157,16 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -1,12 +1,11 @@
 import axios from 'axios'
 import invariant from 'tiny-invariant'
-import { getSymmetricKey } from '../actions/getSymmetricKey.js'
 import {
   RENEGADE_AUTH_HEADER_NAME,
   RENEGADE_SIG_EXPIRATION_HEADER_NAME,
   SIG_EXPIRATION_BUFFER_MS,
 } from '../constants.js'
-import type { BaseConfig, Config } from '../createConfig.js'
+import type { BaseConfig, Config, RenegadeConfig } from '../createConfig.js'
 import { BaseError } from '../errors/base.js'
 import { parseBigJSON } from './bigJSON.js'
 import type { AuthType } from './websocket.js'
@@ -106,7 +105,7 @@ export async function getRelayerRaw(url: string, headers = {}) {
 }
 
 export async function postRelayerWithAuth(
-  config: Config,
+  config: RenegadeConfig,
   url: string,
   body?: string,
   requestType?: AuthType,
@@ -153,8 +152,8 @@ export async function postRelayerWithAdmin(
   return await postRelayerRaw(url, body, headersWithAuth)
 }
 
-export async function getRelayerWithAuth(config: Config, url: string) {
-  const symmetricKey = getSymmetricKey(config)
+export async function getRelayerWithAuth(config: RenegadeConfig, url: string) {
+  const symmetricKey = config.getSymmetricKey()
   invariant(symmetricKey, 'Failed to derive symmetric key')
 
   const path = getPathFromUrl(url)

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2809,6 +2809,7 @@ dependencies = [
  "hmac",
  "indexmap",
  "itertools 0.10.5",
+ "js-sys",
  "k256",
  "lazy_static",
  "num-bigint",
@@ -2823,6 +2824,7 @@ dependencies = [
  "sha2",
  "uuid 1.10.0",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -20,6 +20,8 @@ renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", default
 sha2 = { version = "0.10.8", features = ["asm"] }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
 
 console_error_panic_hook = { version = "0.1.7", optional = true }
 

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -2,13 +2,7 @@
 
 use super::types::{ApiOrder, ApiOrderType, ApiPrivateKeychain, ApiWallet, SignedExternalQuote};
 use crate::{
-    circuit_types::{
-        balance::Balance,
-        fixed_point::FixedPoint,
-        order::OrderSide,
-        transfers::{to_contract_external_transfer, ExternalTransfer, ExternalTransferDirection},
-        Amount,
-    },
+    circuit_types::{balance::Balance, fixed_point::FixedPoint, order::OrderSide, Amount},
     common::{
         derivation::{
             derive_blinder_seed, derive_sk_root_scalars, derive_sk_root_signing_key,
@@ -22,15 +16,11 @@ use crate::{
     },
     key_rotation::handle_key_rotation,
     sign_commitment,
-    signature::sign_wallet_commitment,
+    signature::{sign_wallet_commitment, sign_withdrawal_authorization},
 };
-use ethers::{
-    types::{Bytes, Signature, U256},
-    utils::keccak256,
-};
+use ethers::types::Bytes;
 use itertools::Itertools;
 use js_sys::Function;
-use k256::ecdsa::SigningKey;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
@@ -229,7 +219,7 @@ pub struct WithdrawBalanceRequest {
 }
 
 #[wasm_bindgen]
-pub fn withdraw(
+pub async fn withdraw(
     seed: &str,
     wallet_str: &str,
     mint: &str,
@@ -237,9 +227,9 @@ pub fn withdraw(
     destination_addr: &str,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
-    let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
@@ -276,22 +266,26 @@ pub fn withdraw(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let comm = new_wallet.get_wallet_share_commitment();
-    let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+        .await
+        .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
-        statement_sig: sig.to_vec(),
+        statement_sig,
         new_root_key: next_public_key,
     };
 
-    let sk_root: SigningKey = SigningKey::try_from(&old_sk_root).unwrap();
-    // Authorize the withdrawal then send the request
-    let withdrawal_sig = authorize_withdrawal(
-        &sk_root,
+    let withdrawal_sig = sign_withdrawal_authorization(
+        &new_wallet,
+        seed,
         mint,
         amount.to_u128().unwrap(),
         destination_addr.clone(),
-    )?;
+        key_type,
+        sign_message.as_ref(),
+    )
+    .await
+    .map_err(|e| JsError::new(&e.to_string()))?;
 
     let req = WithdrawBalanceRequest {
         amount,
@@ -300,35 +294,6 @@ pub fn withdraw(
         update_auth,
     };
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))
-}
-
-/// Generate an authorization for a withdrawal
-fn authorize_withdrawal(
-    sk_root: &SigningKey,
-    mint: BigUint,
-    amount: Amount,
-    account_addr: BigUint,
-) -> Result<Signature, JsError> {
-    // Construct a transfer
-
-    let transfer = ExternalTransfer {
-        mint,
-        amount,
-        direction: ExternalTransferDirection::Withdrawal,
-        account_addr,
-    };
-
-    // Sign the transfer with the root key
-    let contract_transfer = to_contract_external_transfer(&transfer).unwrap();
-    let buf = serialize_calldata(&contract_transfer)?;
-    let digest = keccak256(&buf);
-    let (sig, recovery_id) = sk_root.sign_prehash_recoverable(&digest)?;
-
-    Ok(Signature {
-        r: U256::from_big_endian(&sig.r().to_bytes()),
-        s: U256::from_big_endian(&sig.s().to_bytes()),
-        v: recovery_id.to_byte() as u64,
-    })
 }
 
 /// Serializes a calldata element for a contract call
@@ -419,7 +384,7 @@ fn create_order(
     })
 }
 
-pub fn create_order_request(
+pub async fn create_order_request(
     seed: &str,
     wallet_str: &str,
     id: &str,
@@ -432,9 +397,9 @@ pub fn create_order_request(
     allow_external_matches: bool,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<CreateOrderRequest, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
-    let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
@@ -460,11 +425,12 @@ pub fn create_order_request(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let comm = new_wallet.get_wallet_share_commitment();
-    let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+        .await
+        .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
-        statement_sig: sig.to_vec(),
+        statement_sig,
         new_root_key: next_public_key,
     };
 
@@ -472,7 +438,7 @@ pub fn create_order_request(
 }
 
 #[wasm_bindgen]
-pub fn new_order(
+pub async fn new_order(
     seed: &str,
     wallet_str: &str,
     id: &str,
@@ -485,6 +451,7 @@ pub fn new_order(
     allow_external_matches: bool,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
     let req = create_order_request(
         seed,
@@ -499,12 +466,14 @@ pub fn new_order(
         allow_external_matches,
         key_type,
         new_public_key,
-    )?;
+        sign_message,
+    )
+    .await?;
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))
 }
 
 #[wasm_bindgen]
-pub fn new_order_in_matching_pool(
+pub async fn new_order_in_matching_pool(
     seed: &str,
     wallet_str: &str,
     id: &str,
@@ -518,6 +487,7 @@ pub fn new_order_in_matching_pool(
     matching_pool: &str,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
     let create_order_req = create_order_request(
         seed,
@@ -532,7 +502,9 @@ pub fn new_order_in_matching_pool(
         allow_external_matches,
         key_type,
         new_public_key,
-    )?;
+        sign_message,
+    )
+    .await?;
     let req = CreateOrderInMatchingPoolRequest {
         order: create_order_req.order,
         update_auth: create_order_req.update_auth,
@@ -550,15 +522,15 @@ pub struct CancelOrderRequest {
 }
 
 #[wasm_bindgen]
-pub fn cancel_order(
+pub async fn cancel_order(
     seed: &str,
     wallet_str: &str,
     order_id: &str,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
-    let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
@@ -580,11 +552,12 @@ pub fn cancel_order(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let comm = new_wallet.get_wallet_share_commitment();
-    let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+        .await
+        .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
-        statement_sig: sig.to_vec(),
+        statement_sig,
         new_root_key: next_public_key,
     };
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -24,6 +24,7 @@ pub mod external_api;
 pub mod helpers;
 pub mod key_rotation;
 pub mod serde_def_types;
+pub mod signature;
 pub mod types;
 pub mod utils;
 // -------------------------

--- a/wasm/src/signature.rs
+++ b/wasm/src/signature.rs
@@ -9,28 +9,45 @@ use crate::{
     circuit_types::transfers::{
         to_contract_external_transfer, ExternalTransfer, ExternalTransferDirection,
     },
-    common::types::Wallet,
-    exports::error::Error,
+    common::{derivation::derive_sk_root_scalars, types::Wallet},
     helpers::{bytes_from_hex_string, bytes_to_hex_string},
+    sign_commitment,
 };
 
-/// Generates a signature by calling the provided sign_message function
+/// Signs a wallet commitment based on key type.
 ///
-/// # Important Notes for `sign_message` Function:
-/// - The `sign_message` function receives a hashed message (using keccak256),
-///   so it should not hash the message again.
-/// - The function should not prefix the message; it should sign the message as is.
-/// - The signature should use `0x00` or `0x01` for the `v` value, following the
-///   standard ECDSA recovery process where these values encode the y-parity of
-///   the curve point. Do not use the Ethereum-specific values `0x1b` or `0x1c`,
-///   which add an offset of 27 for blockchain-specific purposes.
-/// - If using libraries like `viem`, avoid using `serializeSignature` as it
-///   normalizes `v` to `0x1b` or `0x1c`. Instead, manually construct the 65-byte
-///   signature by concatenating `r`, `s`, and the standard recovery byte (`0x00` or `0x01`).
+/// Internal type uses seed to derive signing key.
+/// External type uses provided sign_message function.
+pub async fn sign_wallet_commitment(
+    wallet: &Wallet,
+    seed: &str,
+    key_type: &str,
+    sign_message: Option<&Function>,
+) -> Result<Vec<u8>, String> {
+    let comm = wallet.get_wallet_share_commitment();
+
+    match key_type {
+        "internal" => {
+            let old_sk_root = derive_sk_root_scalars(seed, &wallet.key_chain.public_keys.nonce);
+            Ok(sign_commitment(&old_sk_root, comm)
+                .map_err(|e| e.to_string())?
+                .to_vec())
+        }
+        "external" => {
+            let sign_message = sign_message.ok_or_else(|| {
+                String::from("sign_message function is required for external key type")
+            })?;
+            generate_signature(wallet, sign_message).await
+        }
+        _ => Err(String::from("Invalid key type")),
+    }
+}
+
+/// Generates a signature by calling the provided sign_message function
 pub async fn generate_signature(
     wallet: &Wallet,
     sign_message: &Function,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Vec<u8>, String> {
     let comm_bytes = wallet
         .get_wallet_share_commitment()
         .inner()
@@ -45,27 +62,31 @@ pub async fn generate_signature(
     let sig_promise: Promise = sign_message
         .call1(&this, &arg)
         .map_err(|e| {
-            Error::sign_message(format!(
+            format!(
                 "Failed to invoke sign_message: {}",
                 e.as_string().unwrap_or_default()
-            ))
+            )
         })?
         .dyn_into()
         .map_err(|e| {
-            Error::sign_message(format!(
+            format!(
                 "Failed to convert Promise to Signature: {}",
                 e.as_string().unwrap_or_default()
-            ))
+            )
         })?;
 
-    let signature = JsFuture::from(sig_promise)
-        .await
-        .map_err(|e| Error::promise_rejected(e.as_string().unwrap_or_default()))?;
+    let signature = JsFuture::from(sig_promise).await.map_err(|e| {
+        format!(
+            "Failed to invoke sign_message: {}",
+            e.as_string().unwrap_or_default()
+        )
+    })?;
 
     let sig_hex = signature
         .as_string()
-        .ok_or_else(|| Error::new("Failed to convert signature to string"))?;
-    let bytes = bytes_from_hex_string(&sig_hex).map_err(|e| Error::sign_message(e.to_string()))?;
+        .ok_or_else(|| String::from("Failed to convert signature to string"))?;
+    let bytes = bytes_from_hex_string(&sig_hex)
+        .map_err(|e| format!("Failed to convert signature to bytes: {}", e))?;
 
     Ok(bytes)
 }
@@ -75,7 +96,7 @@ pub async fn authorize_withdrawal(
     mint: BigUint,
     amount: u128,
     account_addr: BigUint,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Vec<u8>, String> {
     let transfer = ExternalTransfer {
         mint,
         amount,
@@ -84,10 +105,10 @@ pub async fn authorize_withdrawal(
     };
 
     let contract_transfer = to_contract_external_transfer(&transfer)
-        .map_err(|_| Error::new("Failed to convert transfer"))?;
+        .map_err(|_| String::from("Failed to convert transfer"))?;
 
     let buf = postcard::to_allocvec(&contract_transfer)
-        .map_err(|e| Error::new(format!("Failed to serialize transfer: {e}")))?;
+        .map_err(|e| format!("Failed to serialize transfer: {e}"))?;
 
     let digest = keccak256(&buf);
     let digest_hex = bytes_to_hex_string(&digest);
@@ -98,27 +119,31 @@ pub async fn authorize_withdrawal(
     let sig_promise: Promise = sign_message
         .call1(&this, &arg)
         .map_err(|e| {
-            Error::sign_message(format!(
+            format!(
                 "Failed to invoke sign_message: {}",
                 e.as_string().unwrap_or_default()
-            ))
+            )
         })?
         .dyn_into()
         .map_err(|e| {
-            Error::sign_message(format!(
+            format!(
                 "Failed to convert Promise to Signature: {}",
                 e.as_string().unwrap_or_default()
-            ))
+            )
         })?;
 
-    let signature = JsFuture::from(sig_promise)
-        .await
-        .map_err(|e| Error::promise_rejected(e.as_string().unwrap_or_default()))?;
+    let signature = JsFuture::from(sig_promise).await.map_err(|e| {
+        format!(
+            "Failed to invoke sign_message: {}",
+            e.as_string().unwrap_or_default()
+        )
+    })?;
 
     let sig_hex = signature
         .as_string()
-        .ok_or_else(|| Error::new("Failed to convert signature to string"))?;
-    let bytes = bytes_from_hex_string(&sig_hex).map_err(|e| Error::sign_message(e.to_string()))?;
+        .ok_or_else(|| String::from("Failed to convert signature to string"))?;
+    let bytes = bytes_from_hex_string(&sig_hex)
+        .map_err(|e| format!("Failed to convert signature to bytes: {}", e))?;
 
     Ok(bytes)
 }

--- a/wasm/src/signature.rs
+++ b/wasm/src/signature.rs
@@ -1,0 +1,124 @@
+use contracts_common::custom_serde::BytesSerializable;
+use ethers::utils::keccak256;
+use js_sys::{Function, Promise};
+use num_bigint::BigUint;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+
+use crate::{
+    circuit_types::transfers::{
+        to_contract_external_transfer, ExternalTransfer, ExternalTransferDirection,
+    },
+    common::types::Wallet,
+    exports::error::Error,
+    helpers::{bytes_from_hex_string, bytes_to_hex_string},
+};
+
+/// Generates a signature by calling the provided sign_message function
+///
+/// # Important Notes for `sign_message` Function:
+/// - The `sign_message` function receives a hashed message (using keccak256),
+///   so it should not hash the message again.
+/// - The function should not prefix the message; it should sign the message as is.
+/// - The signature should use `0x00` or `0x01` for the `v` value, following the
+///   standard ECDSA recovery process where these values encode the y-parity of
+///   the curve point. Do not use the Ethereum-specific values `0x1b` or `0x1c`,
+///   which add an offset of 27 for blockchain-specific purposes.
+/// - If using libraries like `viem`, avoid using `serializeSignature` as it
+///   normalizes `v` to `0x1b` or `0x1c`. Instead, manually construct the 65-byte
+///   signature by concatenating `r`, `s`, and the standard recovery byte (`0x00` or `0x01`).
+pub async fn generate_signature(
+    wallet: &Wallet,
+    sign_message: &Function,
+) -> Result<Vec<u8>, Error> {
+    let comm_bytes = wallet
+        .get_wallet_share_commitment()
+        .inner()
+        .serialize_to_bytes();
+
+    let digest = keccak256(comm_bytes);
+    let digest_hex = bytes_to_hex_string(&digest);
+
+    let this = JsValue::null();
+    let arg = JsValue::from_str(&digest_hex);
+
+    let sig_promise: Promise = sign_message
+        .call1(&this, &arg)
+        .map_err(|e| {
+            Error::sign_message(format!(
+                "Failed to invoke sign_message: {}",
+                e.as_string().unwrap_or_default()
+            ))
+        })?
+        .dyn_into()
+        .map_err(|e| {
+            Error::sign_message(format!(
+                "Failed to convert Promise to Signature: {}",
+                e.as_string().unwrap_or_default()
+            ))
+        })?;
+
+    let signature = JsFuture::from(sig_promise)
+        .await
+        .map_err(|e| Error::promise_rejected(e.as_string().unwrap_or_default()))?;
+
+    let sig_hex = signature
+        .as_string()
+        .ok_or_else(|| Error::new("Failed to convert signature to string"))?;
+    let bytes = bytes_from_hex_string(&sig_hex).map_err(|e| Error::sign_message(e.to_string()))?;
+
+    Ok(bytes)
+}
+
+pub async fn authorize_withdrawal(
+    sign_message: &Function,
+    mint: BigUint,
+    amount: u128,
+    account_addr: BigUint,
+) -> Result<Vec<u8>, Error> {
+    let transfer = ExternalTransfer {
+        mint,
+        amount,
+        direction: ExternalTransferDirection::Withdrawal,
+        account_addr,
+    };
+
+    let contract_transfer = to_contract_external_transfer(&transfer)
+        .map_err(|_| Error::new("Failed to convert transfer"))?;
+
+    let buf = postcard::to_allocvec(&contract_transfer)
+        .map_err(|e| Error::new(format!("Failed to serialize transfer: {e}")))?;
+
+    let digest = keccak256(&buf);
+    let digest_hex = bytes_to_hex_string(&digest);
+
+    let this = JsValue::null();
+    let arg = JsValue::from_str(&digest_hex);
+
+    let sig_promise: Promise = sign_message
+        .call1(&this, &arg)
+        .map_err(|e| {
+            Error::sign_message(format!(
+                "Failed to invoke sign_message: {}",
+                e.as_string().unwrap_or_default()
+            ))
+        })?
+        .dyn_into()
+        .map_err(|e| {
+            Error::sign_message(format!(
+                "Failed to convert Promise to Signature: {}",
+                e.as_string().unwrap_or_default()
+            ))
+        })?;
+
+    let signature = JsFuture::from(sig_promise)
+        .await
+        .map_err(|e| Error::promise_rejected(e.as_string().unwrap_or_default()))?;
+
+    let sig_hex = signature
+        .as_string()
+        .ok_or_else(|| Error::new("Failed to convert signature to string"))?;
+    let bytes = bytes_from_hex_string(&sig_hex).map_err(|e| Error::sign_message(e.to_string()))?;
+
+    Ok(bytes)
+}

--- a/wasm/src/signature.rs
+++ b/wasm/src/signature.rs
@@ -1,6 +1,10 @@
 use contracts_common::custom_serde::BytesSerializable;
-use ethers::utils::keccak256;
+use ethers::{
+    types::{Signature, U256},
+    utils::keccak256,
+};
 use js_sys::{Function, Promise};
+use k256::ecdsa::SigningKey;
 use num_bigint::BigUint;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -11,91 +15,29 @@ use crate::{
     },
     common::{derivation::derive_sk_root_scalars, types::Wallet},
     helpers::{bytes_from_hex_string, bytes_to_hex_string},
-    sign_commitment,
 };
 
-/// Signs a wallet commitment based on key type.
-///
-/// Internal type uses seed to derive signing key.
-/// External type uses provided sign_message function.
+/// Signs a wallet commitment.
 pub async fn sign_wallet_commitment(
     wallet: &Wallet,
     seed: &str,
     key_type: &str,
-    sign_message: Option<&Function>,
+    external_signer: Option<&Function>,
 ) -> Result<Vec<u8>, String> {
     let comm = wallet.get_wallet_share_commitment();
-
-    match key_type {
-        "internal" => {
-            let old_sk_root = derive_sk_root_scalars(seed, &wallet.key_chain.public_keys.nonce);
-            Ok(sign_commitment(&old_sk_root, comm)
-                .map_err(|e| e.to_string())?
-                .to_vec())
-        }
-        "external" => {
-            let sign_message = sign_message.ok_or_else(|| {
-                String::from("sign_message function is required for external key type")
-            })?;
-            generate_signature(wallet, sign_message).await
-        }
-        _ => Err(String::from("Invalid key type")),
-    }
+    let comm_bytes = comm.inner().serialize_to_bytes();
+    sign_message(wallet, seed, &comm_bytes, key_type, external_signer).await
 }
 
-/// Generates a signature by calling the provided sign_message function
-pub async fn generate_signature(
+/// Signs a withdrawal authorization.
+pub async fn sign_withdrawal_authorization(
     wallet: &Wallet,
-    sign_message: &Function,
-) -> Result<Vec<u8>, String> {
-    let comm_bytes = wallet
-        .get_wallet_share_commitment()
-        .inner()
-        .serialize_to_bytes();
-
-    let digest = keccak256(comm_bytes);
-    let digest_hex = bytes_to_hex_string(&digest);
-
-    let this = JsValue::null();
-    let arg = JsValue::from_str(&digest_hex);
-
-    let sig_promise: Promise = sign_message
-        .call1(&this, &arg)
-        .map_err(|e| {
-            format!(
-                "Failed to invoke sign_message: {}",
-                e.as_string().unwrap_or_default()
-            )
-        })?
-        .dyn_into()
-        .map_err(|e| {
-            format!(
-                "Failed to convert Promise to Signature: {}",
-                e.as_string().unwrap_or_default()
-            )
-        })?;
-
-    let signature = JsFuture::from(sig_promise).await.map_err(|e| {
-        format!(
-            "Failed to invoke sign_message: {}",
-            e.as_string().unwrap_or_default()
-        )
-    })?;
-
-    let sig_hex = signature
-        .as_string()
-        .ok_or_else(|| String::from("Failed to convert signature to string"))?;
-    let bytes = bytes_from_hex_string(&sig_hex)
-        .map_err(|e| format!("Failed to convert signature to bytes: {}", e))?;
-
-    Ok(bytes)
-}
-
-pub async fn authorize_withdrawal(
-    sign_message: &Function,
+    seed: &str,
     mint: BigUint,
     amount: u128,
     account_addr: BigUint,
+    key_type: &str,
+    external_signer: Option<&Function>,
 ) -> Result<Vec<u8>, String> {
     let transfer = ExternalTransfer {
         mint,
@@ -107,10 +49,66 @@ pub async fn authorize_withdrawal(
     let contract_transfer = to_contract_external_transfer(&transfer)
         .map_err(|_| String::from("Failed to convert transfer"))?;
 
-    let buf = postcard::to_allocvec(&contract_transfer)
+    let contract_transfer_bytes = postcard::to_allocvec(&contract_transfer)
         .map_err(|e| format!("Failed to serialize transfer: {e}"))?;
 
-    let digest = keccak256(&buf);
+    sign_message(
+        wallet,
+        seed,
+        &contract_transfer_bytes,
+        key_type,
+        external_signer,
+    )
+    .await
+}
+
+/// Signs a message using either internal or external signing method.
+///
+/// For internal signing, uses the seed to derive a signing key.
+/// For external signing, uses the provided external_signer function.
+pub async fn sign_message(
+    wallet: &Wallet,
+    seed: &str,
+    message: &[u8],
+    key_type: &str,
+    external_signer: Option<&Function>,
+) -> Result<Vec<u8>, String> {
+    match key_type {
+        "internal" => sign_with_internal_key(wallet, seed, message),
+        "external" => sign_with_external_key(message, external_signer).await,
+        _ => Err(String::from("Invalid key type")),
+    }
+}
+
+/// Helper function to sign a message with a derived SigningKey and return an Ethers Signature
+fn sign_with_internal_key(wallet: &Wallet, seed: &str, message: &[u8]) -> Result<Vec<u8>, String> {
+    let sk_root_scalars = derive_sk_root_scalars(seed, &wallet.key_chain.public_keys.nonce);
+    let sk_root: SigningKey = SigningKey::try_from(&sk_root_scalars)
+        .map_err(|_| String::from("Failed to create signing key"))?;
+
+    let digest = keccak256(message);
+    let (sig, recovery_id) = sk_root
+        .sign_prehash_recoverable(&digest)
+        .map_err(|_| String::from("Failed to sign message"))?;
+
+    let signature = Signature {
+        r: U256::from_big_endian(&sig.r().to_bytes()),
+        s: U256::from_big_endian(&sig.s().to_bytes()),
+        v: recovery_id.to_byte() as u64,
+    };
+
+    Ok(signature.to_vec())
+}
+
+/// Generates a signature by calling the provided sign_message function with a message
+async fn sign_with_external_key(
+    message: &[u8],
+    external_signer: Option<&Function>,
+) -> Result<Vec<u8>, String> {
+    let sign_message = external_signer
+        .ok_or_else(|| String::from("sign_message function is required for external key type"))?;
+
+    let digest = keccak256(message);
     let digest_hex = bytes_to_hex_string(&digest);
 
     let this = JsValue::null();


### PR DESCRIPTION
### Purpose
This PR implements the deposit task for external key configs. In doing so, a discriminated union type `RenegadeConfig` was created to allow for type narrowing based on `renegadeKeyType`, and helper functions were updated to ingest this change.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet