### PR TITLE
wasm, core: impl external key withdraw action

### DIFF
--- a/packages/core/src/actions/cancelOrder.ts
+++ b/packages/core/src/actions/cancelOrder.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
 import type { Hex } from 'viem'
 import { CANCEL_ORDER_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { RenegadeConfig } from '../createConfig.js'
 import type { BaseErrorType } from '../errors/base.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
 import { postRelayerWithAuth } from '../utils/http.js'
@@ -18,27 +18,37 @@ export type CancelOrderReturnType = { taskId: string }
 export type CancelOrderErrorType = BaseErrorType
 
 export async function cancelOrder(
-  config: Config,
+  config: RenegadeConfig,
   parameters: CancelOrderParameters,
 ): Promise<CancelOrderReturnType> {
   const { id, newPublicKey } = parameters
-  const {
-    getBaseUrl,
-    utils,
-    state: { seed },
-    renegadeKeyType,
-  } = config
-  invariant(seed, 'Seed is required')
+  const { getBaseUrl, utils, renegadeKeyType } = config
 
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.cancel_order(
-    seed,
+  const seed = renegadeKeyType === 'internal' ? config.state.seed : undefined
+  const signMessage =
+    renegadeKeyType === 'external' ? config.signMessage : undefined
+
+  if (renegadeKeyType === 'external') {
+    invariant(
+      signMessage !== undefined,
+      'Sign message function is required for external key type',
+    )
+  }
+  if (renegadeKeyType === 'internal') {
+    invariant(seed !== undefined, 'Seed is required for internal key type')
+  }
+
+  const body = await utils.cancel_order(
+    // TODO: Change Rust to accept Option<String>
+    seed ?? '',
     stringifyForWasm(wallet),
     id,
     renegadeKeyType,
     newPublicKey,
+    signMessage,
   )
 
   try {

--- a/packages/core/src/actions/createOrderInMatchingPool.ts
+++ b/packages/core/src/actions/createOrderInMatchingPool.ts
@@ -41,7 +41,7 @@ export async function createOrderInMatchingPool(
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.new_order_in_matching_pool(
+  const body = await utils.new_order_in_matching_pool(
     seed,
     stringifyForWasm(wallet),
     id,

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -60,9 +60,10 @@ export function withdraw(seed: string, wallet_str: string, mint: string, amount:
 * @param {boolean} allow_external_matches
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string): any;
+export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -77,18 +78,20 @@ export function new_order(seed: string, wallet_str: string, id: string, base_min
 * @param {string} matching_pool
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string): any;
+export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
 * @param {string} order_id
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string): any;
+export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -43,9 +43,10 @@ export function deposit(seed: string, wallet_str: string, from_addr: string, min
 * @param {string} destination_addr
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function withdraw(seed: string, wallet_str: string, mint: string, amount: string, destination_addr: string, key_type: string, new_public_key?: string): any;
+export function withdraw(seed: string, wallet_str: string, mint: string, amount: string, destination_addr: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -131,19 +132,6 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
-/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -166,3 +154,16 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -132,6 +132,19 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
+/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -154,16 +167,3 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
-/**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -132,19 +132,6 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
-/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -167,3 +154,16 @@ export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;

--- a/wasm/src/signature.rs
+++ b/wasm/src/signature.rs
@@ -1,18 +1,55 @@
 use contracts_common::custom_serde::BytesSerializable;
-use ethers::utils::keccak256;
+use ethers::{
+    types::{Signature, U256},
+    utils::keccak256,
+};
 use js_sys::{Function, Promise};
+use k256::ecdsa::SigningKey;
 use num_bigint::BigUint;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::{
-    circuit_types::transfers::{
-        to_contract_external_transfer, ExternalTransfer, ExternalTransferDirection,
+    circuit_types::{
+        transfers::{to_contract_external_transfer, ExternalTransfer, ExternalTransferDirection},
+        Amount,
     },
     common::{derivation::derive_sk_root_scalars, types::Wallet},
+    external_api::http::serialize_calldata,
     helpers::{bytes_from_hex_string, bytes_to_hex_string},
     sign_commitment,
 };
+
+/// Signs a withdrawal authorization based on key type.
+///
+/// Internal type uses seed to derive signing key.
+/// External type uses provided sign_message function.
+pub async fn sign_withdrawal_authorization(
+    wallet: &Wallet,
+    seed: &str,
+    mint: BigUint,
+    amount: u128,
+    account_addr: BigUint,
+    key_type: &str,
+    sign_message: Option<&Function>,
+) -> Result<Vec<u8>, String> {
+    match key_type {
+        "internal" => {
+            let old_sk_root = derive_sk_root_scalars(seed, &wallet.key_chain.public_keys.nonce);
+            let sk_root: SigningKey = SigningKey::try_from(&old_sk_root).unwrap();
+            let sig = authorize_withdrawal_internal(&sk_root, mint, amount, account_addr)
+                .map_err(|_| format!("Failed to authorize withdrawal"))?;
+            Ok(sig.to_vec())
+        }
+        "external" => {
+            let sign_message = sign_message.ok_or_else(|| {
+                String::from("sign_message function is required for external key type")
+            })?;
+            authorize_withdrawal_external(sign_message, mint, amount, account_addr).await
+        }
+        _ => Err(format!("Invalid key type: {key_type}")),
+    }
+}
 
 /// Signs a wallet commitment based on key type.
 ///
@@ -37,23 +74,19 @@ pub async fn sign_wallet_commitment(
             let sign_message = sign_message.ok_or_else(|| {
                 String::from("sign_message function is required for external key type")
             })?;
-            generate_signature(wallet, sign_message).await
+            let comm_bytes = comm.inner().serialize_to_bytes();
+            generate_signature(&comm_bytes, sign_message).await
         }
         _ => Err(String::from("Invalid key type")),
     }
 }
 
-/// Generates a signature by calling the provided sign_message function
+/// Generates a signature by calling the provided sign_message function with a message
 pub async fn generate_signature(
-    wallet: &Wallet,
+    message: &[u8],
     sign_message: &Function,
 ) -> Result<Vec<u8>, String> {
-    let comm_bytes = wallet
-        .get_wallet_share_commitment()
-        .inner()
-        .serialize_to_bytes();
-
-    let digest = keccak256(comm_bytes);
+    let digest = keccak256(message);
     let digest_hex = bytes_to_hex_string(&digest);
 
     let this = JsValue::null();
@@ -91,7 +124,7 @@ pub async fn generate_signature(
     Ok(bytes)
 }
 
-pub async fn authorize_withdrawal(
+pub async fn authorize_withdrawal_external(
     sign_message: &Function,
     mint: BigUint,
     amount: u128,
@@ -110,40 +143,34 @@ pub async fn authorize_withdrawal(
     let buf = postcard::to_allocvec(&contract_transfer)
         .map_err(|e| format!("Failed to serialize transfer: {e}"))?;
 
+    generate_signature(&buf, sign_message).await
+}
+
+/// Generate an authorization for a withdrawal
+fn authorize_withdrawal_internal(
+    sk_root: &SigningKey,
+    mint: BigUint,
+    amount: Amount,
+    account_addr: BigUint,
+) -> Result<Signature, JsError> {
+    // Construct a transfer
+
+    let transfer = ExternalTransfer {
+        mint,
+        amount,
+        direction: ExternalTransferDirection::Withdrawal,
+        account_addr,
+    };
+
+    // Sign the transfer with the root key
+    let contract_transfer = to_contract_external_transfer(&transfer).unwrap();
+    let buf = serialize_calldata(&contract_transfer)?;
     let digest = keccak256(&buf);
-    let digest_hex = bytes_to_hex_string(&digest);
+    let (sig, recovery_id) = sk_root.sign_prehash_recoverable(&digest)?;
 
-    let this = JsValue::null();
-    let arg = JsValue::from_str(&digest_hex);
-
-    let sig_promise: Promise = sign_message
-        .call1(&this, &arg)
-        .map_err(|e| {
-            format!(
-                "Failed to invoke sign_message: {}",
-                e.as_string().unwrap_or_default()
-            )
-        })?
-        .dyn_into()
-        .map_err(|e| {
-            format!(
-                "Failed to convert Promise to Signature: {}",
-                e.as_string().unwrap_or_default()
-            )
-        })?;
-
-    let signature = JsFuture::from(sig_promise).await.map_err(|e| {
-        format!(
-            "Failed to invoke sign_message: {}",
-            e.as_string().unwrap_or_default()
-        )
-    })?;
-
-    let sig_hex = signature
-        .as_string()
-        .ok_or_else(|| String::from("Failed to convert signature to string"))?;
-    let bytes = bytes_from_hex_string(&sig_hex)
-        .map_err(|e| format!("Failed to convert signature to bytes: {}", e))?;
-
-    Ok(bytes)
+    Ok(Signature {
+        r: U256::from_big_endian(&sig.r().to_bytes()),
+        s: U256::from_big_endian(&sig.s().to_bytes()),
+        v: recovery_id.to_byte() as u64,
+    })
 }


### PR DESCRIPTION
### Purpose
This PR allows externally managed keys to use the withdraw task. It creates helper functions to decide what signing function to use based on the key type.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet