### PR TITLE
wasm, core: impl external key create order action

### DIFF
--- a/packages/core/src/actions/cancelOrder.ts
+++ b/packages/core/src/actions/cancelOrder.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
 import type { Hex } from 'viem'
 import { CANCEL_ORDER_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { RenegadeConfig } from '../createConfig.js'
 import type { BaseErrorType } from '../errors/base.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
 import { postRelayerWithAuth } from '../utils/http.js'
@@ -18,27 +18,37 @@ export type CancelOrderReturnType = { taskId: string }
 export type CancelOrderErrorType = BaseErrorType
 
 export async function cancelOrder(
-  config: Config,
+  config: RenegadeConfig,
   parameters: CancelOrderParameters,
 ): Promise<CancelOrderReturnType> {
   const { id, newPublicKey } = parameters
-  const {
-    getBaseUrl,
-    utils,
-    state: { seed },
-    renegadeKeyType,
-  } = config
-  invariant(seed, 'Seed is required')
+  const { getBaseUrl, utils, renegadeKeyType } = config
 
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.cancel_order(
-    seed,
+  const seed = renegadeKeyType === 'internal' ? config.state.seed : undefined
+  const signMessage =
+    renegadeKeyType === 'external' ? config.signMessage : undefined
+
+  if (renegadeKeyType === 'external') {
+    invariant(
+      signMessage !== undefined,
+      'Sign message function is required for external key type',
+    )
+  }
+  if (renegadeKeyType === 'internal') {
+    invariant(seed !== undefined, 'Seed is required for internal key type')
+  }
+
+  const body = await utils.cancel_order(
+    // TODO: Change Rust to accept Option<String>
+    seed ?? '',
     stringifyForWasm(wallet),
     id,
     renegadeKeyType,
     newPublicKey,
+    signMessage,
   )
 
   try {

--- a/packages/core/src/actions/createOrderInMatchingPool.ts
+++ b/packages/core/src/actions/createOrderInMatchingPool.ts
@@ -41,7 +41,7 @@ export async function createOrderInMatchingPool(
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.new_order_in_matching_pool(
+  const body = await utils.new_order_in_matching_pool(
     seed,
     stringifyForWasm(wallet),
     id,

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -88,9 +88,10 @@ export function new_order_in_matching_pool(seed: string, wallet_str: string, id:
 * @param {string} order_id
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string): any;
+export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -60,9 +60,10 @@ export function withdraw(seed: string, wallet_str: string, mint: string, amount:
 * @param {boolean} allow_external_matches
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string): any;
+export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str
@@ -77,9 +78,10 @@ export function new_order(seed: string, wallet_str: string, id: string, base_min
 * @param {string} matching_pool
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string): any;
+export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -366,7 +366,7 @@ fn create_order(
     })
 }
 
-pub fn create_order_request(
+pub async fn create_order_request(
     seed: &str,
     wallet_str: &str,
     id: &str,
@@ -379,9 +379,9 @@ pub fn create_order_request(
     allow_external_matches: bool,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<CreateOrderRequest, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
-    let old_sk_root = derive_sk_root_scalars(seed, &new_wallet.key_chain.public_keys.nonce);
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
@@ -407,11 +407,12 @@ pub fn create_order_request(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let comm = new_wallet.get_wallet_share_commitment();
-    let sig = wrap_eyre!(sign_commitment(&old_sk_root, comm)).unwrap();
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+        .await
+        .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
-        statement_sig: sig.to_vec(),
+        statement_sig,
         new_root_key: next_public_key,
     };
 
@@ -419,7 +420,7 @@ pub fn create_order_request(
 }
 
 #[wasm_bindgen]
-pub fn new_order(
+pub async fn new_order(
     seed: &str,
     wallet_str: &str,
     id: &str,
@@ -432,6 +433,7 @@ pub fn new_order(
     allow_external_matches: bool,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
     let req = create_order_request(
         seed,
@@ -446,12 +448,14 @@ pub fn new_order(
         allow_external_matches,
         key_type,
         new_public_key,
-    )?;
+        sign_message,
+    )
+    .await?;
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))
 }
 
 #[wasm_bindgen]
-pub fn new_order_in_matching_pool(
+pub async fn new_order_in_matching_pool(
     seed: &str,
     wallet_str: &str,
     id: &str,
@@ -465,6 +469,7 @@ pub fn new_order_in_matching_pool(
     matching_pool: &str,
     key_type: &str,
     new_public_key: Option<String>,
+    sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
     let create_order_req = create_order_request(
         seed,
@@ -479,7 +484,8 @@ pub fn new_order_in_matching_pool(
         allow_external_matches,
         key_type,
         new_public_key,
-    )?;
+        sign_message,
+    ).await?;
     let req = CreateOrderInMatchingPoolRequest {
         order: create_order_req.order,
         update_auth: create_order_req.update_auth,


### PR DESCRIPTION
### Purpose
This PR allows externally managed wallets to create orders.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet