### PR TITLE
wasm, core: impl external key cancel order action

### DIFF
--- a/packages/core/src/actions/cancelOrder.ts
+++ b/packages/core/src/actions/cancelOrder.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
 import type { Hex } from 'viem'
 import { CANCEL_ORDER_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { RenegadeConfig } from '../createConfig.js'
 import type { BaseErrorType } from '../errors/base.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
 import { postRelayerWithAuth } from '../utils/http.js'
@@ -18,27 +18,37 @@ export type CancelOrderReturnType = { taskId: string }
 export type CancelOrderErrorType = BaseErrorType
 
 export async function cancelOrder(
-  config: Config,
+  config: RenegadeConfig,
   parameters: CancelOrderParameters,
 ): Promise<CancelOrderReturnType> {
   const { id, newPublicKey } = parameters
-  const {
-    getBaseUrl,
-    utils,
-    state: { seed },
-    renegadeKeyType,
-  } = config
-  invariant(seed, 'Seed is required')
+  const { getBaseUrl, utils, renegadeKeyType } = config
 
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  const body = utils.cancel_order(
-    seed,
+  const seed = renegadeKeyType === 'internal' ? config.state.seed : undefined
+  const signMessage =
+    renegadeKeyType === 'external' ? config.signMessage : undefined
+
+  if (renegadeKeyType === 'external') {
+    invariant(
+      signMessage !== undefined,
+      'Sign message function is required for external key type',
+    )
+  }
+  if (renegadeKeyType === 'internal') {
+    invariant(seed !== undefined, 'Seed is required for internal key type')
+  }
+
+  const body = await utils.cancel_order(
+    // TODO: Change Rust to accept Option<String>
+    seed ?? '',
     stringifyForWasm(wallet),
     id,
     renegadeKeyType,
     newPublicKey,
+    signMessage,
   )
 
   try {

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -88,9 +88,10 @@ export function new_order_in_matching_pool(seed: string, wallet_str: string, id:
 * @param {string} order_id
 * @param {string} key_type
 * @param {string | undefined} [new_public_key]
-* @returns {any}
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string): any;
+export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str


### PR DESCRIPTION
### Purpose
This PR allows externally managed wallets to cancel orders.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet