### PR TITLE
wasm, core: remove need for key_type in Rust context

### DIFF
--- a/packages/core/src/actions/cancelOrder.ts
+++ b/packages/core/src/actions/cancelOrder.ts
@@ -42,8 +42,7 @@ export async function cancelOrder(
   }
 
   const body = await utils.cancel_order(
-    // TODO: Change Rust to accept Option<String>
-    seed ?? '',
+    seed,
     stringifyForWasm(wallet),
     id,
     newPublicKey,

--- a/packages/core/src/actions/cancelOrder.ts
+++ b/packages/core/src/actions/cancelOrder.ts
@@ -46,7 +46,6 @@ export async function cancelOrder(
     seed ?? '',
     stringifyForWasm(wallet),
     id,
-    renegadeKeyType,
     newPublicKey,
     signMessage,
   )

--- a/packages/core/src/actions/createOrder.ts
+++ b/packages/core/src/actions/createOrder.ts
@@ -48,7 +48,6 @@ export async function createOrder(
   const signMessage =
     renegadeKeyType === 'external' ? config.signMessage : undefined
 
-  // TODO: Add invariants to other actions
   if (renegadeKeyType === 'external') {
     invariant(
       signMessage !== undefined,
@@ -60,8 +59,7 @@ export async function createOrder(
   }
 
   const body = await utils.new_order(
-    // TODO: Change Rust to accept Option<String>
-    seed ?? '',
+    seed,
     stringifyForWasm(wallet),
     id,
     base,

--- a/packages/core/src/actions/createOrder.ts
+++ b/packages/core/src/actions/createOrder.ts
@@ -71,7 +71,6 @@ export async function createOrder(
     worstCasePrice,
     toHex(minFillSize),
     allowExternalMatches,
-    renegadeKeyType,
     newPublicKey,
     signMessage,
   )

--- a/packages/core/src/actions/deposit.ts
+++ b/packages/core/src/actions/deposit.ts
@@ -51,7 +51,6 @@ export async function deposit(
     toHex(permitNonce),
     toHex(permitDeadline),
     permit,
-    renegadeKeyType,
     newPublicKey,
     signMessage,
   )

--- a/packages/core/src/actions/deposit.ts
+++ b/packages/core/src/actions/deposit.ts
@@ -1,4 +1,5 @@
 import { type Address, toHex } from 'viem'
+import invariant from 'tiny-invariant'
 import { DEPOSIT_BALANCE_ROUTE } from '../constants.js'
 import type { RenegadeConfig } from '../createConfig.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
@@ -41,9 +42,19 @@ export async function deposit(
   const signMessage =
     renegadeKeyType === 'external' ? config.signMessage : undefined
 
+  if (renegadeKeyType === 'external') {
+    invariant(
+      signMessage !== undefined,
+      'Sign message function is required for external key type',
+    )
+  }
+  if (renegadeKeyType === 'internal') {
+    invariant(seed !== undefined, 'Seed is required for internal key type')
+  }
+
   const body = await utils.deposit(
     // TODO: Change Rust to accept Option<String>
-    seed ?? '',
+    seed,
     stringifyForWasm(wallet),
     fromAddr,
     mint,

--- a/packages/core/src/actions/withdraw.ts
+++ b/packages/core/src/actions/withdraw.ts
@@ -35,7 +35,6 @@ export async function withdraw(
     mint,
     toHex(amount),
     destinationAddr,
-    renegadeKeyType,
     newPublicKey,
     signMessage,
   )

--- a/packages/core/src/actions/withdraw.ts
+++ b/packages/core/src/actions/withdraw.ts
@@ -1,4 +1,5 @@
 import { type Address, toHex } from 'viem'
+import invariant from 'tiny-invariant'
 import { WITHDRAW_BALANCE_ROUTE } from '../constants.js'
 import type { RenegadeConfig } from '../createConfig.js'
 import { stringifyForWasm } from '../utils/bigJSON.js'
@@ -29,8 +30,18 @@ export async function withdraw(
   const signMessage =
     renegadeKeyType === 'external' ? config.signMessage : undefined
 
+  if (renegadeKeyType === 'external') {
+    invariant(
+      signMessage !== undefined,
+      'Sign message function is required for external key type',
+    )
+  }
+  if (renegadeKeyType === 'internal') {
+    invariant(seed !== undefined, 'Seed is required for internal key type')
+  }
+
   const body = await utils.withdraw(
-    seed ?? '',
+    seed,
     stringifyForWasm(wallet),
     mint,
     toHex(amount),

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -21,7 +21,7 @@ export function derive_blinder_share(seed: string): any;
 */
 export function wallet_id(seed: string): any;
 /**
-* @param {string} seed
+* @param {string | undefined} seed
 * @param {string} wallet_str
 * @param {string} from_addr
 * @param {string} mint
@@ -29,26 +29,24 @@ export function wallet_id(seed: string): any;
 * @param {string} permit_nonce
 * @param {string} permit_deadline
 * @param {string} permit_signature
-* @param {string} key_type
 * @param {string | undefined} [new_public_key]
 * @param {Function | undefined} [sign_message]
 * @returns {Promise<any>}
 */
-export function deposit(seed: string, wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
+export function deposit(seed: string | undefined, wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
-* @param {string} seed
+* @param {string | undefined} seed
 * @param {string} wallet_str
 * @param {string} mint
 * @param {string} amount
 * @param {string} destination_addr
-* @param {string} key_type
 * @param {string | undefined} [new_public_key]
 * @param {Function | undefined} [sign_message]
 * @returns {Promise<any>}
 */
-export function withdraw(seed: string, wallet_str: string, mint: string, amount: string, destination_addr: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
+export function withdraw(seed: string | undefined, wallet_str: string, mint: string, amount: string, destination_addr: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
-* @param {string} seed
+* @param {string | undefined} seed
 * @param {string} wallet_str
 * @param {string} id
 * @param {string} base_mint
@@ -58,14 +56,13 @@ export function withdraw(seed: string, wallet_str: string, mint: string, amount:
 * @param {string} worst_case_price
 * @param {string} min_fill_size
 * @param {boolean} allow_external_matches
-* @param {string} key_type
 * @param {string | undefined} [new_public_key]
 * @param {Function | undefined} [sign_message]
 * @returns {Promise<any>}
 */
-export function new_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
+export function new_order(seed: string | undefined, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
-* @param {string} seed
+* @param {string | undefined} seed
 * @param {string} wallet_str
 * @param {string} id
 * @param {string} base_mint
@@ -76,22 +73,20 @@ export function new_order(seed: string, wallet_str: string, id: string, base_min
 * @param {string} min_fill_size
 * @param {boolean} allow_external_matches
 * @param {string} matching_pool
-* @param {string} key_type
 * @param {string | undefined} [new_public_key]
 * @param {Function | undefined} [sign_message]
 * @returns {Promise<any>}
 */
-export function new_order_in_matching_pool(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
+export function new_order_in_matching_pool(seed: string | undefined, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, matching_pool: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
-* @param {string} seed
+* @param {string | undefined} seed
 * @param {string} wallet_str
 * @param {string} order_id
-* @param {string} key_type
 * @param {string | undefined} [new_public_key]
 * @param {Function | undefined} [sign_message]
 * @returns {Promise<any>}
 */
-export function cancel_order(seed: string, wallet_str: string, order_id: string, key_type: string, new_public_key?: string, sign_message?: Function): Promise<any>;
+export function cancel_order(seed: string | undefined, wallet_str: string, order_id: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {string} wallet_str

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -142,7 +142,7 @@ pub struct DepositBalanceRequest {
 
 #[wasm_bindgen]
 pub async fn deposit(
-    seed: &str,
+    seed: Option<String>,
     wallet_str: &str,
     from_addr: &str,
     mint: &str,
@@ -150,7 +150,6 @@ pub async fn deposit(
     permit_nonce: &str,
     permit_deadline: &str,
     permit_signature: &str,
-    key_type: &str,
     new_public_key: Option<String>,
     sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
@@ -158,8 +157,7 @@ pub async fn deposit(
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
-        seed,
-        key_type,
+        seed.as_deref(),
         new_public_key
     ))
     .unwrap();
@@ -175,7 +173,7 @@ pub async fn deposit(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
         .await
         .map_err(|e| JsError::new(&e.to_string()))?;
 
@@ -220,12 +218,11 @@ pub struct WithdrawBalanceRequest {
 
 #[wasm_bindgen]
 pub async fn withdraw(
-    seed: &str,
+    seed: Option<String>,
     wallet_str: &str,
     mint: &str,
     amount: &str,
     destination_addr: &str,
-    key_type: &str,
     new_public_key: Option<String>,
     sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
@@ -233,8 +230,7 @@ pub async fn withdraw(
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
-        seed,
-        key_type,
+        seed.as_deref(),
         new_public_key
     ))
     .unwrap();
@@ -266,7 +262,7 @@ pub async fn withdraw(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
         .await
         .map_err(|e| JsError::new(&e.to_string()))?;
 
@@ -277,11 +273,10 @@ pub async fn withdraw(
 
     let withdrawal_sig = sign_withdrawal_authorization(
         &new_wallet,
-        seed,
+        seed.as_deref(),
         mint,
         amount.to_u128().unwrap(),
         destination_addr.clone(),
-        key_type,
         sign_message.as_ref(),
     )
     .await
@@ -385,7 +380,7 @@ fn create_order(
 }
 
 pub async fn create_order_request(
-    seed: &str,
+    seed: Option<String>,
     wallet_str: &str,
     id: &str,
     base_mint: &str,
@@ -395,7 +390,6 @@ pub async fn create_order_request(
     worst_case_price: &str,
     min_fill_size: &str,
     allow_external_matches: bool,
-    key_type: &str,
     new_public_key: Option<String>,
     sign_message: Option<Function>,
 ) -> Result<CreateOrderRequest, JsError> {
@@ -403,8 +397,7 @@ pub async fn create_order_request(
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
-        seed,
-        key_type,
+        seed.as_deref(),
         new_public_key
     ))
     .unwrap();
@@ -425,7 +418,7 @@ pub async fn create_order_request(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
         .await
         .map_err(|e| JsError::new(&e.to_string()))?;
 
@@ -439,7 +432,7 @@ pub async fn create_order_request(
 
 #[wasm_bindgen]
 pub async fn new_order(
-    seed: &str,
+    seed: Option<String>,
     wallet_str: &str,
     id: &str,
     base_mint: &str,
@@ -449,7 +442,6 @@ pub async fn new_order(
     worst_case_price: &str,
     min_fill_size: &str,
     allow_external_matches: bool,
-    key_type: &str,
     new_public_key: Option<String>,
     sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
@@ -464,7 +456,6 @@ pub async fn new_order(
         worst_case_price,
         min_fill_size,
         allow_external_matches,
-        key_type,
         new_public_key,
         sign_message,
     )
@@ -474,7 +465,7 @@ pub async fn new_order(
 
 #[wasm_bindgen]
 pub async fn new_order_in_matching_pool(
-    seed: &str,
+    seed: Option<String>,
     wallet_str: &str,
     id: &str,
     base_mint: &str,
@@ -485,7 +476,6 @@ pub async fn new_order_in_matching_pool(
     min_fill_size: &str,
     allow_external_matches: bool,
     matching_pool: &str,
-    key_type: &str,
     new_public_key: Option<String>,
     sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
@@ -500,7 +490,6 @@ pub async fn new_order_in_matching_pool(
         worst_case_price,
         min_fill_size,
         allow_external_matches,
-        key_type,
         new_public_key,
         sign_message,
     )
@@ -523,10 +512,9 @@ pub struct CancelOrderRequest {
 
 #[wasm_bindgen]
 pub async fn cancel_order(
-    seed: &str,
+    seed: Option<String>,
     wallet_str: &str,
     order_id: &str,
-    key_type: &str,
     new_public_key: Option<String>,
     sign_message: Option<Function>,
 ) -> Result<JsValue, JsError> {
@@ -534,8 +522,7 @@ pub async fn cancel_order(
 
     let next_public_key = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
-        seed,
-        key_type,
+        seed.as_deref(),
         new_public_key
     ))
     .unwrap();
@@ -552,7 +539,7 @@ pub async fn cancel_order(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed, key_type, sign_message.as_ref())
+    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
         .await
         .map_err(|e| JsError::new(&e.to_string()))?;
 


### PR DESCRIPTION
### Purpose
This PR makes changes to how we determine the key type of a wallet. We enforce in Javascript that externally managed keys must provide a sign callback and internally managed keys must provide a seed. This obviates the need to pass `key_type` as a parameter as we can now rely on the presence of either of these functions to branch.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet