### PR TITLE
wasm, core: impl external key get pk scalars

### DIFF
--- a/packages/core/src/actions/getPkRoot.ts
+++ b/packages/core/src/actions/getPkRoot.ts
@@ -1,9 +1,9 @@
 import invariant from 'tiny-invariant'
 import type { Hex } from 'viem'
-import type { Config } from '../createConfig.js'
+import type { Config, RenegadeConfig } from '../createConfig.js'
 
 export type GetPkRootParameters = {
-  nonce: bigint
+  nonce?: bigint
 }
 
 export type GetPkRootReturnType = Hex
@@ -18,19 +18,25 @@ export function getPkRoot(
   } = config
   const { nonce } = parameters
   invariant(seed, 'Seed is required')
+  invariant(nonce, 'Nonce is required')
   return `0x${utils.get_pk_root(seed, nonce)}`
 }
 
 export function getPkRootScalars(
-  config: Config,
-  parameters: GetPkRootParameters = { nonce: BigInt(0) },
+  config: RenegadeConfig,
+  parameters: GetPkRootParameters = {},
 ): GetPkRootScalarsReturnType {
-  const {
-    utils,
-    state: { seed },
-  } = config
+  const { utils, renegadeKeyType } = config
   const { nonce } = parameters
-  invariant(seed, 'Seed is required')
-  const scalars = utils.get_pk_root_scalars(seed, nonce)
+
+  const seed = renegadeKeyType === 'internal' ? config.state.seed : undefined
+  const publicKey = renegadeKeyType === 'external' ? config.publicKey : undefined
+
+  if (renegadeKeyType === 'internal') {
+    invariant(seed !== undefined, 'Seed is required for internal key type')
+    invariant(nonce !== undefined, 'Nonce is required for internal key type')
+  }
+
+  const scalars = utils.get_pk_root_scalars(seed, nonce, publicKey)
   return scalars.map((s: string) => BigInt(s)).slice(0, 4)
 }

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -248,6 +248,12 @@ export {
   createAuthConfig,
 } from '../createAuthConfig.js'
 
+export {
+  type CreateExternalKeyConfigParameters,
+  type ExternalConfig,
+  createExternalKeyConfig,
+} from '../createExternalKeyConfig.js'
+
 ////////////////////////////////////////////////////////////////////////////////
 // createStorage
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -2,6 +2,30 @@
 /* eslint-disable */
 /**
 * @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
+/**
+* @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function get_pk_root(seed: string, nonce: bigint): any;
+/**
+* @param {string | undefined} [seed]
+* @param {bigint | undefined} [nonce]
+* @param {string | undefined} [public_key]
+* @returns {any[]}
+*/
+export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: string): any[];
+/**
+* @param {string} seed
+* @returns {any}
+*/
+export function get_symmetric_key(seed: string): any;
+/**
+* @param {string} seed
 * @returns {any}
 */
 export function create_wallet(seed: string): any;
@@ -129,29 +153,6 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 * @returns {any}
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function get_pk_root(seed: string, nonce: bigint): any;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any[]}
-*/
-export function get_pk_root_scalars(seed: string, nonce: bigint): any[];
-/**
-* @param {string} seed
-* @returns {any}
-*/
-export function get_symmetric_key(seed: string): any;
 /**
 * @param {string} path
 * @param {any} headers

--- a/packages/node/src/exports/index.ts
+++ b/packages/node/src/exports/index.ts
@@ -5,6 +5,7 @@ export * from '@renegade-fi/core/constants'
 import {
   createAuthConfig as core_createAuthConfig,
   createConfig as core_createConfig,
+  createExternalKeyConfig as core_createExternalKeyConfig,
 } from '@renegade-fi/core'
 
 import * as RustUtils from '../../renegade-utils/index.js'
@@ -29,7 +30,17 @@ function createAuthConfig(
   return config
 }
 
-export { createAuthConfig, createConfig }
+function createExternalKeyConfig(
+  ...args: Parameters<typeof core_createExternalKeyConfig>
+): ReturnType<typeof core_createExternalKeyConfig> {
+  const config = core_createExternalKeyConfig({
+    ...args[0],
+    utils: RustUtils,
+  })
+  return config
+}
+
+export { createAuthConfig, createConfig, createExternalKeyConfig }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Actions


### PR DESCRIPTION
### Purpose
This PR modifies the existing `getPkRoot` action to use the public key in an external config if provided. This is primarly used to retrieve the witness value for permit2 signatures, which is the non-rotated `pkRoot` scalars. Also exports `createExternalConfig` for testing.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet