### PR TITLE
wasm, core: impl external key refresh wallet

### DIFF
--- a/packages/core/src/actions/refreshWallet.ts
+++ b/packages/core/src/actions/refreshWallet.ts
@@ -1,11 +1,15 @@
 import { REFRESH_WALLET_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { RenegadeConfig } from '../createConfig.js'
 import { postRelayerWithAuth } from '../utils/http.js'
 import { getWalletId } from './getWalletId.js'
 
-export type RefreshWalletReturnType = Promise<{ taskId: string }>
+export type RefreshWalletReturnType = {
+  taskId: string
+}
 
-export async function refreshWallet(config: Config): RefreshWalletReturnType {
+export async function refreshWallet(
+  config: RenegadeConfig,
+): Promise<RefreshWalletReturnType> {
   const { getBaseUrl } = config
   const walletId = getWalletId(config)
 


### PR DESCRIPTION
### Purpose
This PR makes the refresh wallet task compatible with externally managed wallets.

### Testing
- [x] Tested locally
- [ ] Tested in testnet