### PR TITLE
wasm, core: impl external key lookup wallet

### DIFF
--- a/packages/core/src/actions/lookupWallet.ts
+++ b/packages/core/src/actions/lookupWallet.ts
@@ -1,36 +1,65 @@
 import invariant from 'tiny-invariant'
 import { parseAbiItem } from 'viem'
 import { FIND_WALLET_ROUTE } from '../constants.js'
-import type { Config } from '../createConfig.js'
+import type { Config, RenegadeConfig } from '../createConfig.js'
 import { BaseError } from '../errors/base.js'
 import { postRelayerRaw } from '../utils/http.js'
 import { waitForWalletIndexing } from './waitForWalletIndexing.js'
 
 export type LookupWalletReturnType = ReturnType<typeof waitForWalletIndexing>
 
-export async function lookupWallet(config: Config): LookupWalletReturnType {
-  const {
-    getBaseUrl,
-    utils,
-    state: { seed },
-  } = config
-  invariant(seed, 'seed is required')
-  const body = utils.find_wallet(seed)
+export type LookupWalletParameters = {
+  blinderSeed?: string
+  shareSeed?: string
+  skMatch?: string
+}
+
+export async function lookupWallet(
+  config: RenegadeConfig,
+  parameters: LookupWalletParameters = {},
+): LookupWalletReturnType {
+  const { getBaseUrl, utils } = config
+  let body: string
+
+  if (config.renegadeKeyType === 'internal') {
+    const { seed } = config.state
+    invariant(seed, 'seed is required')
+    body = utils.find_wallet(seed)
+  } else {
+    const { blinderSeed, shareSeed, skMatch } = parameters
+    const { walletId, publicKey, symmetricKey } = config
+    invariant(blinderSeed, 'blinderSeed is required')
+    invariant(shareSeed, 'shareSeed is required')
+    invariant(skMatch, 'skMatch is required')
+    body = await utils.find_external_wallet(
+      walletId,
+      blinderSeed,
+      shareSeed,
+      publicKey,
+      skMatch,
+      symmetricKey,
+    )
+  }
   const res = await postRelayerRaw(getBaseUrl(FIND_WALLET_ROUTE), body)
+
   if (res.task_id) {
     console.log(`task lookup-wallet(${res.task_id}): ${res.wallet_id}`, {
       status: 'looking up',
       walletId: res.wallet_id,
     })
-    config.setState((x) => ({ ...x, status: 'looking up' }))
+    if (config.renegadeKeyType === 'internal') {
+      config.setState((x) => ({ ...x, status: 'looking up' }))
+    }
     return waitForWalletIndexing(config, {
       timeout: 300000,
       isLookup: true,
       onComplete(wallet) {
-        config.setState((x) => ({
-          ...x,
-          status: 'in relayer',
-        }))
+        if (config.renegadeKeyType === 'internal') {
+          config.setState((x) => ({
+            ...x,
+            status: 'in relayer',
+          }))
+        }
         console.log(
           `task lookup-wallet(${res.task_id}) completed: ${wallet.id}`,
           {
@@ -40,11 +69,12 @@ export async function lookupWallet(config: Config): LookupWalletReturnType {
         )
       },
       onFailure() {
-        console.error(`wallet id: ${config.state.id} looking up failed`, {
-          status: 'looking up',
-          walletId: config.state.id,
-        })
-        config.setState({})
+        console.log(
+          `task lookup-wallet(${res.task_id}) failed: ${res.wallet_id}`,
+        )
+        if (config.renegadeKeyType === 'internal') {
+          config.setState({})
+        }
       },
     })
   }

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -1,19 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
-/**
 * @param {Function} sign_message
 * @returns {Promise<any>}
 */
@@ -28,30 +15,6 @@ export function generate_wallet_secrets(sign_message: Function): Promise<any>;
 * @returns {Promise<any>}
 */
 export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function get_pk_root(seed: string, nonce: bigint): any;
-/**
-* @param {string | undefined} [seed]
-* @param {bigint | undefined} [nonce]
-* @param {string | undefined} [public_key]
-* @returns {any[]}
-*/
-export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: string): any[];
-/**
-* @param {string} seed
-* @returns {any}
-*/
-export function get_symmetric_key(seed: string): any;
 /**
 * @param {string} seed
 * @returns {any}
@@ -181,3 +144,50 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 * @returns {any}
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
+/**
+* @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function get_pk_root(seed: string, nonce: bigint): any;
+/**
+* @param {string | undefined} [seed]
+* @param {bigint | undefined} [nonce]
+* @param {string | undefined} [public_key]
+* @returns {any[]}
+*/
+export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: string): any[];
+/**
+* @param {string} seed
+* @returns {any}
+*/
+export function get_symmetric_key(seed: string): any;

--- a/wasm/src/external_api/find_wallet.rs
+++ b/wasm/src/external_api/find_wallet.rs
@@ -1,0 +1,93 @@
+use num_bigint::BigUint;
+use uuid::Uuid;
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    circuit_types::keychain::{PublicKeyChain, PublicSigningKey, SecretIdentificationKey},
+    common::keychain::{HmacKey, KeyChain, PrivateKeyChain},
+    external_api::http::FindWalletRequest,
+    helpers::{biguint_from_hex_string, bytes_from_hex_string},
+    js_error, serialize_to_js,
+    types::Scalar,
+};
+
+use super::types::ApiKeychain;
+
+#[wasm_bindgen]
+pub async fn find_external_wallet(
+    wallet_id: &str,
+    blinder_seed: &str,
+    share_seed: &str,
+    pk_root: &str,
+    sk_match: &str,
+    symmetric_key: &str,
+) -> Result<JsValue, JsError> {
+    let params = FindWalletParameters::new(
+        wallet_id,
+        blinder_seed,
+        share_seed,
+        pk_root,
+        sk_match,
+        symmetric_key,
+    )?;
+
+    let request = FindWalletRequest {
+        wallet_id: params.wallet_id,
+        blinder_seed: params.blinder_seed,
+        secret_share_seed: params.share_seed,
+        private_keychain: params.key_chain.private_keys,
+    };
+
+    serialize_to_js!(request)
+}
+pub struct FindWalletParameters {
+    pub wallet_id: Uuid,
+    pub blinder_seed: BigUint,
+    pub share_seed: BigUint,
+    pub key_chain: ApiKeychain,
+}
+
+impl FindWalletParameters {
+    pub fn new(
+        wallet_id: &str,
+        blinder_seed: &str,
+        share_seed: &str,
+        pk_root: &str,
+        sk_match: &str,
+        symmetric_key: &str,
+    ) -> Result<Self, JsError> {
+        // Wallet seed info
+        let wallet_id = Uuid::parse_str(wallet_id).map_err(|e| js_error!("wallet_id: {}", e))?;
+        let blinder_seed =
+            biguint_from_hex_string(blinder_seed).map_err(|e| js_error!("blinder_seed: {}", e))?;
+        let share_seed =
+            biguint_from_hex_string(share_seed).map_err(|e| js_error!("share_seed: {}", e))?;
+
+        // KeyChain
+        let sk_match_bigint =
+            biguint_from_hex_string(sk_match).map_err(|e| js_error!("sk_match: {}", e))?;
+        let sk_match_scalar = Scalar::from(sk_match_bigint);
+        let sk_match = SecretIdentificationKey::from(sk_match_scalar);
+        let pk_match = sk_match.get_public_key();
+        let pk_root_bytes =
+            bytes_from_hex_string(pk_root).map_err(|e| js_error!("pk_root: {}", e))?;
+        let pk_root = PublicSigningKey::from_bytes(&pk_root_bytes)
+            .map_err(|e| js_error!("pk_root: {}", e))?;
+        let symmetric_key = HmacKey::from_hex_string(symmetric_key)
+            .map_err(|e| js_error!("symmetric_key: {}", e))?;
+        let key_chain = KeyChain {
+            public_keys: PublicKeyChain::new(pk_root, pk_match),
+            secret_keys: PrivateKeyChain {
+                sk_root: None,
+                sk_match,
+                symmetric_key,
+            },
+        };
+        Ok(Self {
+            wallet_id,
+            blinder_seed,
+            share_seed,
+            key_chain: key_chain.into(),
+        })
+    }
+}

--- a/wasm/src/external_api/mod.rs
+++ b/wasm/src/external_api/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
 pub mod create_wallet;
+pub mod find_wallet;
 pub mod http;
 pub mod types;


### PR DESCRIPTION
### Purpose
This PR makes the lookup wallet action compatible with externally managed keys. Similarly to create wallet, the Rust util function was broken out into a separate function since there is no overlap with the internally manged key version.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet