### PR TITLE
wasm: sign wallet comm using correct signing key

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.4.14
+
+### Patch Changes
+
+- wasm: sign wallet using correct signing key
+
 ## 0.4.13
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -6,15 +6,18 @@
 */
 export function generate_wallet_secrets(sign_message: Function): Promise<any>;
 /**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
 */
-export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
 /**
 * @param {string} seed
 * @returns {any}
@@ -145,18 +148,15 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, signed_quote: string): any;
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
 */
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
+export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
 /**
 * @param {string} wallet_id
 * @param {string} blinder_seed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.4.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.14
+
 ## 0.4.13
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.4.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.14
+
 ## 0.4.14
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.3.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.4.14
+
 ## 0.3.12
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -155,7 +155,7 @@ pub async fn deposit(
 ) -> Result<JsValue, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
 
-    let next_public_key = wrap_eyre!(handle_key_rotation(
+    let (next_public_key, signing_key) = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
         seed.as_deref(),
         new_public_key
@@ -173,9 +173,10 @@ pub async fn deposit(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
-        .await
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let statement_sig =
+        sign_wallet_commitment(&new_wallet, signing_key.as_ref(), sign_message.as_ref())
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
         statement_sig,
@@ -228,7 +229,7 @@ pub async fn withdraw(
 ) -> Result<JsValue, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
 
-    let next_public_key = wrap_eyre!(handle_key_rotation(
+    let (next_public_key, signing_key) = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
         seed.as_deref(),
         new_public_key
@@ -262,9 +263,10 @@ pub async fn withdraw(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
-        .await
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let statement_sig =
+        sign_wallet_commitment(&new_wallet, signing_key.as_ref(), sign_message.as_ref())
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
         statement_sig,
@@ -272,9 +274,8 @@ pub async fn withdraw(
     };
 
     let withdrawal_sig = sign_withdrawal_authorization(
-        &new_wallet,
-        seed.as_deref(),
-        mint,
+        signing_key.as_ref(),
+        mint.clone(),
         amount.to_u128().unwrap(),
         destination_addr.clone(),
         sign_message.as_ref(),
@@ -285,7 +286,7 @@ pub async fn withdraw(
     let req = WithdrawBalanceRequest {
         amount,
         destination_addr,
-        external_transfer_sig: withdrawal_sig.to_vec(),
+        external_transfer_sig: withdrawal_sig,
         update_auth,
     };
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))
@@ -395,7 +396,7 @@ pub async fn create_order_request(
 ) -> Result<CreateOrderRequest, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
 
-    let next_public_key = wrap_eyre!(handle_key_rotation(
+    let (next_public_key, signing_key) = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
         seed.as_deref(),
         new_public_key
@@ -418,9 +419,10 @@ pub async fn create_order_request(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
-        .await
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let statement_sig =
+        sign_wallet_commitment(&new_wallet, signing_key.as_ref(), sign_message.as_ref())
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
         statement_sig,
@@ -520,7 +522,7 @@ pub async fn cancel_order(
 ) -> Result<JsValue, JsError> {
     let mut new_wallet = deserialize_wallet(wallet_str);
 
-    let next_public_key = wrap_eyre!(handle_key_rotation(
+    let (next_public_key, signing_key) = wrap_eyre!(handle_key_rotation(
         &mut new_wallet,
         seed.as_deref(),
         new_public_key
@@ -539,9 +541,10 @@ pub async fn cancel_order(
     new_wallet.reblind_wallet();
 
     // Sign a commitment to the new shares
-    let statement_sig = sign_wallet_commitment(&new_wallet, seed.as_deref(), sign_message.as_ref())
-        .await
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let statement_sig =
+        sign_wallet_commitment(&new_wallet, signing_key.as_ref(), sign_message.as_ref())
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
 
     let update_auth = WalletUpdateAuthorization {
         statement_sig,


### PR DESCRIPTION
### Purpose
This PR fixes an issue where the rotated keychain was used to derive a signing key that was resulting in invalid wallet update signatures. To do so, the correct signing key is returned by `handle_keychain_rotation`, and is used as the signing key for internal wallets.

### Testing
- [x] Tested locally
- [ ] Tested in testnet