### PR TITLE
core: utils: http: include query string in path for auth

### DIFF
--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -222,7 +222,7 @@ export async function postWithSymmetricKey(
 function getPathFromUrl(url: string): string {
   try {
     const parsedUrl = new URL(url)
-    return parsedUrl.pathname || '/'
+    return parsedUrl.pathname + parsedUrl.search || '/'
   } catch {
     return url.startsWith('/') ? url : `/${url}`
   }


### PR DESCRIPTION
This PR updates the `getPathFromUrl` helper used in making authenticated requests to the relayer to include the query string in the path. As of https://github.com/renegade-fi/renegade/pull/884, this is now expected to be present for authenticating requests that include query strings.

### Testing
I tested this against a local relayer (running https://github.com/renegade-fi/renegade/pull/884) and using a local frontend that ran with a canary release of these changes. I asserted that the task history endpoint could be successfully invoked when the `task_history_len` parameter was set.