### PR TITLE
node: Accept external key config in executeWithdrawal action

### DIFF
--- a/packages/node/src/actions/executeWithdrawal.ts
+++ b/packages/node/src/actions/executeWithdrawal.ts
@@ -1,5 +1,5 @@
 import {
-  type Config,
+  type RenegadeConfig,
   type WithdrawParameters,
   type WithdrawReturnType,
   getWalletId,
@@ -9,11 +9,11 @@ import {
 } from '@renegade-fi/core'
 
 export type ExecuteWithdrawalParameters = WithdrawParameters & {
-  awaitTask: boolean
+  awaitTask?: boolean
 }
 
 export async function executeWithdrawal(
-  config: Config,
+  config: RenegadeConfig,
   parameters: ExecuteWithdrawalParameters,
 ): WithdrawReturnType {
   const walletId = getWalletId(config)


### PR DESCRIPTION
### Purpose
This PR updates the `executeWithdrawal` action to be compatible with both external configs and internal configs.

### Testing
- [x] Tested locally using canary deployment
- [ ] Tested in testnet