### PR TITLE
node: Use simulate + write contract pattern for approval tx

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/node
 
+## 0.4.19
+
+### Patch Changes
+
+- node: Use simulate + write contract pattern for approval tx
+
 ## 0.4.18
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",


### PR DESCRIPTION
### Purpose
This PR implements the [suggested](https://viem.sh/docs/contract/writeContract.html#usage) pattern of pairing `simulateContract` with `writeContract` to validate that the contract write will execute without errors. This fixes an issue we saw with sending approval transactions on testnet.

The deposit transaction is attempted even if the transaction receipt is not received. This is because we often miss transaction receipts in testnet.

This replaces helper functions generated by `@wagmi/cli`.

### Testing
- [x] Tested locally against testnet
- [x] Tested locally against mainnet