### PR TITLE
core: Use HSE in order history and task history actions

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.5.0
+
+### Minor Changes
+
+- core: Use HSE in order history and task history actions
+
 ## 0.4.19
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.4.19",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/actions/getOrderHistory.ts
+++ b/packages/core/src/actions/getOrderHistory.ts
@@ -1,3 +1,4 @@
+import { getHseBaseUrl } from '../chains/defaults.js'
 import { ORDER_HISTORY_LEN_PARAM, ORDER_HISTORY_ROUTE } from '../constants.js'
 import type { RenegadeConfig } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
@@ -17,11 +18,11 @@ export async function getOrderHistory(
   config: RenegadeConfig,
   parameters: GetOrderHistoryParameters = {},
 ): Promise<GetOrderHistoryReturnType> {
-  const { getBaseUrl } = config
   const { limit } = parameters
+  const hseBaseUrl = getHseBaseUrl(config.chainId)
   const walletId = getWalletId(config)
 
-  let url = getBaseUrl(ORDER_HISTORY_ROUTE(walletId))
+  let url = `${hseBaseUrl}/v0${ORDER_HISTORY_ROUTE(walletId)}`
 
   if (limit !== undefined) {
     const searchParams = new URLSearchParams({

--- a/packages/core/src/actions/getTaskHistory.ts
+++ b/packages/core/src/actions/getTaskHistory.ts
@@ -1,11 +1,10 @@
-import { getWalletId } from './getWalletId.js'
-
-import { getRelayerWithAuth } from '../utils/http.js'
-
+import { getHseBaseUrl } from '../chains/defaults.js'
 import { TASK_HISTORY_LEN_PARAM, TASK_HISTORY_ROUTE } from '../constants.js'
 import type { RenegadeConfig } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
 import type { Task as TaskHistoryItem } from '../types/task.js'
+import { getRelayerWithAuth } from '../utils/http.js'
+import { getWalletId } from './getWalletId.js'
 
 export type GetTaskHistoryParameters = {
   limit?: number
@@ -19,10 +18,9 @@ export async function getTaskHistory(
   config: RenegadeConfig,
   parameters: GetTaskHistoryParameters = {},
 ): Promise<GetTaskHistoryReturnType> {
-  const { getBaseUrl } = config
   const { limit } = parameters
   const walletId = getWalletId(config)
-  let url = getBaseUrl(TASK_HISTORY_ROUTE(walletId))
+  let url = `${getHseBaseUrl(config.chainId)}/v0${TASK_HISTORY_ROUTE(walletId)}`
 
   if (limit !== undefined) {
     const searchParams = new URLSearchParams({

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -1,0 +1,33 @@
+import { arbitrum, arbitrumSepolia } from 'viem/chains'
+
+type ConfigDefaults = {
+  hseBaseUrl: string
+}
+
+const SUPPORTED_CHAINS = [arbitrum.id, arbitrumSepolia.id] as const
+export type SupportedChainId = (typeof SUPPORTED_CHAINS)[number]
+
+const CHAIN_DEFAULTS: Record<SupportedChainId, ConfigDefaults> = {
+  [arbitrum.id]: {
+    hseBaseUrl: 'https://mainnet.historical-state.renegade.fi:3000',
+  },
+  [arbitrumSepolia.id]: {
+    hseBaseUrl: 'https://testnet.historical-state.renegade.fi:3000',
+  },
+}
+
+export function getHseBaseUrl(chainId: SupportedChainId): string {
+  const defaults = CHAIN_DEFAULTS[chainId]
+  if (!defaults) {
+    throw new Error(`No HSE base URL found for chain ID ${chainId}`)
+  }
+
+  return defaults.hseBaseUrl
+}
+
+// Utility function to check if a chain ID is supported
+export function isSupportedChainId(
+  chainId: number,
+): chainId is SupportedChainId {
+  return SUPPORTED_CHAINS.some((chain) => chain === chainId)
+}

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -9,6 +9,7 @@ import {
 import { arbitrumSepolia } from 'viem/chains'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
 import { type Mutate, type StoreApi, createStore } from 'zustand/vanilla'
+import type { SupportedChainId } from './chains/defaults.js'
 import type { ExternalConfig } from './createExternalKeyConfig.js'
 import { type Storage, createStorage, noopStorage } from './createStorage.js'
 import type { Evaluate, ExactPartial } from './types/utils.js'
@@ -16,6 +17,7 @@ import type * as rustUtils from './utils.d.ts'
 import { AuthType } from './utils/websocket.js'
 
 export type CreateConfigParameters = {
+  chainId: SupportedChainId
   darkPoolAddress: Address
   priceReporterUrl: string
   relayerUrl: string
@@ -179,6 +181,7 @@ export function createConfig(
       store,
       ssr: Boolean(ssr),
     },
+    chainId: parameters.chainId,
   }
 }
 
@@ -190,6 +193,7 @@ export type BaseConfig = {
 }
 
 export type Config = BaseConfig & {
+  chainId: SupportedChainId
   renegadeKeyType: 'internal'
   readonly storage: Storage | null
   darkPoolAddress: Address

--- a/packages/core/src/createExternalKeyConfig.ts
+++ b/packages/core/src/createExternalKeyConfig.ts
@@ -1,9 +1,11 @@
 import invariant from 'tiny-invariant'
 import type { Address, PublicClient, SignMessageReturnType } from 'viem'
+import type { SupportedChainId } from './chains/defaults.js'
 import type { BaseConfig } from './createConfig.js'
 import type * as rustUtils from './utils.d.ts'
 
 export type CreateExternalKeyConfigParameters = {
+  chainId: SupportedChainId
   /** URL of the relayer service */
   relayerUrl: string
   /** URL of the websocket service */
@@ -82,10 +84,12 @@ export function createExternalKeyConfig(
     },
     viemClient,
     darkPoolAddress,
+    chainId: parameters.chainId,
   }
 }
 
 export type ExternalConfig = BaseConfig & {
+  chainId: SupportedChainId
   relayerUrl: string
   signMessage: (message: string) => Promise<SignMessageReturnType>
   symmetricKey: `0x${string}`

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -29,7 +29,6 @@ export {
   type CreateOrderRequestReturnType,
   createOrderRequest,
 } from '../actions/createOrderRequest.js'
-
 export {
   type CreateWalletReturnType,
   type CreateWalletParameters,
@@ -337,3 +336,5 @@ export {
 } from '../utils/websocketWaiter.js'
 
 export { parseBigJSON, stringifyForWasm } from '../utils/bigJSON.js'
+
+export { isSupportedChainId } from '../chains/defaults.js'

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -1,6 +1,24 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
+* @param {Function} sign_message
+* @returns {Promise<any>}
+*/
+export function generate_wallet_secrets(sign_message: Function): Promise<any>;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
+/**
 * @param {string} seed
 * @returns {any}
 */
@@ -139,24 +157,6 @@ export function assemble_external_match(do_gas_estimation: boolean, updated_orde
 * @returns {Promise<any>}
 */
 export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {Function} sign_message
-* @returns {Promise<any>}
-*/
-export function generate_wallet_secrets(sign_message: Function): Promise<any>;
-/**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
 /**
 * @param {string} wallet_id
 * @param {string} blinder_seed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @renegade-fi/node
 
+## 0.5.0
+
+### Minor Changes
+
+- node: chore
+
+## 0.4.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.0
+
 ## 0.4.20
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.4.20",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @renegade-fi/react
 
+## 0.5.0
+
+### Minor Changes
+
+- core: Use HSE in order history and task history actions
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.0
+
 ## 0.4.20
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.4.20",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -245,6 +245,7 @@ export {
   deepEqual,
   parseCookie,
   stringifyForWasm,
+  isSupportedChainId,
   // Types
   OrderState,
   TaskType,

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @renegade-fi/test
 
+## 0.4.0
+
+### Minor Changes
+
+- core: Use HSE in order history and task history actions
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.0
+
 ## 0.3.18
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.3.18",
+  "version": "0.4.0",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/packages/test/src/testConfig.ts
+++ b/packages/test/src/testConfig.ts
@@ -3,6 +3,7 @@ import { createConfig } from '@renegade-fi/core'
 import * as RustUtils from '../../react/renegade-utils/index.js'
 
 export const config = createConfig({
+  chainId: 421614,
   darkPoolAddress: '0x000000000000000000000000000000000000000',
   priceReporterUrl: 'https://price-reporter.renegade.fi',
   relayerUrl: '127.0.0.1',


### PR DESCRIPTION
### Purpose
This PR modifies the `getOrderHistory` and `getTaskHistory` actions to use the Historical State Engine as the default server to fetch from. The URL is set based on the chain ID that the consumer must now set to create a config, which is a breaking change. In a future PR, this chain ID will be used to derive default values for other config parameters (e.g. relayer base URL, websocket URL, etc.). This is done in a type safe way—consumers will see suggestions when defining chain ID and will also have access to a utility function `isSupportedChainId` to type narrow the value (e.g. when using an environment variable).

If the need to configure the HSE base URL arises that change can be made, but for now we use the default to reduce complexity.

### Testing
- [x] Tested locally
- [x] Test in testnet