### PR TITLE
core: actions: assembleExternalQuote, getExternalMatchBundle: gas sponsorship options

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -220,3 +220,8 @@ export const REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE = '/matching-engine/quote'
 /// The route for assembling an external match
 export const ASSEMBLE_EXTERNAL_MATCH_ROUTE =
   '/matching-engine/assemble-external-match'
+
+/// The query parameter for using gas sponsorship
+export const GAS_SPONSORSHIP_PARAM = 'use_gas_sponsorship'
+/// The query parameter for the gas sponsorship refund address
+export const REFUND_ADDRESS_PARAM = 'refund_address'

--- a/packages/core/src/types/externalMatch.ts
+++ b/packages/core/src/types/externalMatch.ts
@@ -26,6 +26,7 @@ export type ExternalSettlementTx = {
   data: `0x${string}`
   accessList: AccessList
   gas?: `0x${string}`
+  value?: `0x${string}`
 }
 
 export type ExternalMatchQuote = {


### PR DESCRIPTION
This PR tweaks the parameters to the `assembleExternalQuote` and `getExternalMatchBundle` actions to accept options for requesting gas sponsorship through the auth server.

### Testing
This has been tested against the testnet stack.