### PR TITLE
core: types: externalMatch: add ExternalMatchResponse type

### DIFF
--- a/packages/core/src/actions/assembleExternalQuote.ts
+++ b/packages/core/src/actions/assembleExternalQuote.ts
@@ -9,7 +9,7 @@ import {
 import type { AuthConfig } from '../createAuthConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
 import type {
-  ExternalMatchBundle,
+  ExternalMatchResponse,
   ExternalOrder,
   SignedExternalMatchQuote,
 } from '../types/externalMatch.js'
@@ -24,7 +24,7 @@ export type AssembleExternalQuoteParameters = {
   refundAddress?: `0x${string}`
 }
 
-export type AssembleExternalQuoteReturnType = ExternalMatchBundle
+export type AssembleExternalQuoteReturnType = ExternalMatchResponse
 
 export type AssembleExternalQuoteErrorType = BaseErrorType
 
@@ -72,5 +72,5 @@ export async function assembleExternalQuote(
   if (!res.match_bundle) {
     throw new BaseError('Failed to assemble external quote')
   }
-  return res.match_bundle
+  return res
 }

--- a/packages/core/src/actions/getExternalMatchBundle.ts
+++ b/packages/core/src/actions/getExternalMatchBundle.ts
@@ -9,7 +9,7 @@ import {
 import type { AuthConfig } from '../createAuthConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
 import type {
-  ExternalMatchBundle,
+  ExternalMatchResponse,
   ExternalOrder,
 } from '../types/externalMatch.js'
 import { postWithSymmetricKey } from '../utils/http.js'
@@ -21,7 +21,7 @@ export type GetExternalMatchBundleParameters = {
   refundAddress?: `0x${string}`
 }
 
-export type GetExternalMatchBundleReturnType = ExternalMatchBundle
+export type GetExternalMatchBundleReturnType = ExternalMatchResponse
 
 export type GetExternalMatchBundleErrorType = BaseErrorType
 
@@ -77,5 +77,5 @@ export async function getExternalMatchBundle(
   if (!res.match_bundle) {
     throw new BaseError('No match bundle found')
   }
-  return res.match_bundle
+  return res
 }

--- a/packages/core/src/types/externalMatch.ts
+++ b/packages/core/src/types/externalMatch.ts
@@ -52,6 +52,11 @@ export type ExternalMatchBundle = {
   fees: FeeTake
 }
 
+export type ExternalMatchResponse = {
+  match_bundle: ExternalMatchBundle
+  is_sponsored: boolean
+}
+
 export type ExternalAssetTransfer = {
   mint: `0x${string}`
   amount: bigint


### PR DESCRIPTION
This PR adds a separate `ExternalMatchResponse` type which mirrors the response shape returned by the auth server.


### Testing
This was tested by invoking external matches against the testnet stack