### PR TITLE
core: define standalone PriceReporterClient

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.2
+  - @renegade-fi/node@0.5.3
+
 ## 1.0.1
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renegade-external-match-example",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/gas-sponsorship/CHANGELOG.md
+++ b/examples/gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.2
+  - @renegade-fi/node@0.5.3
+
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/gas-sponsorship/package.json
+++ b/examples/gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/gas-sponsorship-example",
     "private": true,
-    "version": "0.0.1",
+    "version": "0.0.2",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.5.2
+
+### Patch Changes
+
+- core: define standalone PriceReporterClient
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,6 +73,7 @@
     "axios": "^1.6.8",
     "isows": "^1.0.6",
     "json-bigint": "^1.0.0",
+    "neverthrow": "^8.2.0",
     "tiny-invariant": "^1.3.3",
     "zustand": "^4.5.2"
   },

--- a/packages/core/src/clients/price-reporter/client.ts
+++ b/packages/core/src/clients/price-reporter/client.ts
@@ -1,0 +1,78 @@
+import type { AxiosRequestConfig } from 'axios'
+import axios from 'axios'
+import { ResultAsync, errAsync, okAsync } from 'neverthrow'
+import { PRICE_REPORTER_ROUTE } from '../../constants.js'
+import { getDefaultQuoteToken } from '../../types/token.js'
+import { HttpError, PriceReporterError } from './error.js'
+
+const ERR_NO_PRICE_REPORTER_URL =
+  'PRICE_REPORTER_URL environment variable is not set'
+const ERR_INVALID_URL =
+  'PRICE_REPORTER_URL must be a valid URL including protocol and port'
+
+export class PriceReporterClient {
+  constructor(private readonly baseUrl: string) {}
+
+  /**
+   * Creates a new PriceReporterClient instance
+   * @returns A Result containing either a PriceReporterClient or a PriceReporterError
+   */
+  static new(): ResultAsync<PriceReporterClient, PriceReporterError> {
+    if (!process.env.PRICE_REPORTER_URL) {
+      return errAsync(new PriceReporterError(ERR_NO_PRICE_REPORTER_URL))
+    }
+
+    try {
+      const baseUrl = new URL(`https://${process.env.PRICE_REPORTER_URL}:3000`)
+      return ResultAsync.fromPromise(
+        Promise.resolve(new PriceReporterClient(baseUrl.toString())),
+        (err: unknown) =>
+          new PriceReporterError(
+            err instanceof Error ? err.message : String(err),
+          ),
+      )
+    } catch {
+      return errAsync(new PriceReporterError(ERR_INVALID_URL))
+    }
+  }
+
+  static getBinancePrice(
+    address: `0x${string}`,
+  ): ResultAsync<number, PriceReporterError> {
+    const exchange = 'binance'
+    const quote = getDefaultQuoteToken(exchange).address
+
+    return PriceReporterClient.new().andThen((client) =>
+      client.getPrice(exchange, address, quote),
+    )
+  }
+
+  public getPrice(
+    exchange: string,
+    address: `0x${string}`,
+    quote: `0x${string}`,
+  ): ResultAsync<number, PriceReporterError> {
+    const route = PRICE_REPORTER_ROUTE(exchange, address, quote)
+    return this.get<string>(route).andThen((textPrice) => {
+      const price = Number(textPrice)
+      return okAsync(price)
+    })
+  }
+
+  private get<T>(route: string): ResultAsync<T, PriceReporterError> {
+    const url = new URL(route, this.baseUrl)
+    const endpointUrl = url.toString()
+
+    const config: AxiosRequestConfig = {
+      method: 'GET',
+      url: endpointUrl,
+    }
+
+    const safeRequest = ResultAsync.fromThrowable(
+      () => axios.request<T>(config),
+      (error) => new HttpError(error, endpointUrl, config.method || 'GET'),
+    )
+
+    return safeRequest().map((response) => response.data)
+  }
+}

--- a/packages/core/src/clients/price-reporter/error.ts
+++ b/packages/core/src/clients/price-reporter/error.ts
@@ -1,0 +1,53 @@
+import axios, { type AxiosError } from 'axios'
+
+export class PriceReporterError extends Error {
+  constructor(message: string) {
+    super(`PriceReporterError: ${message}`)
+    Object.setPrototypeOf(this, PriceReporterError.prototype)
+  }
+}
+
+export class HttpError extends PriceReporterError {
+  public status?: number
+  public details?: unknown
+
+  /**
+   * Creates a new HttpError with detailed error information
+   * @param error - The original error (typically an AxiosError)
+   * @param url - The URL that was being accessed
+   * @param method - The HTTP method that was being used
+   * @param customMessage - Optional custom message prefix (defaults to "HTTP request failed")
+   */
+  constructor(
+    error: unknown,
+    url: string,
+    method: string,
+    customMessage = 'HTTP request failed',
+  ) {
+    const requestInfo = `[${method.toUpperCase()}] ${url}`
+    let finalMessage = `${customMessage} - ${requestInfo}`
+
+    if (axios.isAxiosError(error)) {
+      const axiosError = error as AxiosError
+      if (axiosError.response) {
+        const { status, statusText, data } = axiosError.response
+        const errorCode = axiosError.code ? ` (${axiosError.code})` : ''
+        const errorMessage = typeof data === 'string' ? `: ${data}` : ''
+        finalMessage = `${finalMessage} - Received ${status} ${statusText}${errorCode}${errorMessage}`
+      } else if (axiosError.request) {
+        finalMessage = `${finalMessage} - No response received from server`
+      } else {
+        finalMessage = `${finalMessage} - Request failed: ${axiosError.message}`
+      }
+    }
+    super(finalMessage)
+    Object.setPrototypeOf(this, HttpError.prototype)
+
+    if (axios.isAxiosError(error) && error.response) {
+      this.status = error.response.status
+      this.details = error.response.data
+    } else {
+      this.details = error
+    }
+  }
+}

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -338,3 +338,13 @@ export {
 export { parseBigJSON, stringifyForWasm } from '../utils/bigJSON.js'
 
 export { isSupportedChainId } from '../chains/defaults.js'
+
+////////////////////////////////////////////////////////////////////////////////
+// Clients
+////////////////////////////////////////////////////////////////////////////////
+
+export { PriceReporterClient } from '../clients/price-reporter/client.js'
+export {
+  PriceReporterError,
+  HttpError,
+} from '../clients/price-reporter/error.js'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.2
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.2
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.5.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       json-bigint:
         specifier: ^1.0.0
         version: 1.0.0
+      neverthrow:
+        specifier: ^8.2.0
+        version: 8.2.0
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -795,6 +798,11 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.21.0':
     resolution: {integrity: sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.35.0':
+    resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
     cpu: [x64]
     os: [linux]
 
@@ -1515,6 +1523,10 @@ packages:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  neverthrow@8.2.0:
+    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2537,6 +2549,9 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.21.0':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.35.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.21.0':
     optional: true
 
@@ -3284,6 +3299,10 @@ snapshots:
   ms@2.1.2: {}
 
   nanoid@3.3.7: {}
+
+  neverthrow@8.2.0:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.35.0
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
### Purpose
This PR defines a price reporter client that does not depend on a `Config` or `RenegadeConfig` object. Such a client is required in the bot server, and is also good practice to decouple hitting the price reporter from the config object meant for interacting with the Relayer API.

### Testing
- [x] Tested locally
- [x] Test in testnet