### PR TITLE
packages: core: use omit_gas_sponsorship query param

### DIFF
--- a/examples/in-kind-gas-sponsorship/README.md
+++ b/examples/in-kind-gas-sponsorship/README.md
@@ -26,7 +26,7 @@ This example demonstrates how to execute trades with gas sponsorship enabled. Th
 
 Here's how it works:
 
-1. Gets a quote for a match with `useGasSponsorship` set to true, `refundNativeEth` set to false, and the `refundAddress` unset.
+1. Gets a quote for a match with `disableGasSponsorship` set to false, `refundNativeEth` set to false, and the `refundAddress` unset.
 2. Assembles the quote with the `receiverAddress` set.
 3. The bundle includes routing through the gas sponsorship contract
 4. At the end of the transaction, the gas sponsorship contract will refund the gas costs to the receiver of the match. You should see the address receive a transfer of the buy-side token approximately equivalent to the costs of the transaction.

--- a/examples/in-kind-gas-sponsorship/index.ts
+++ b/examples/in-kind-gas-sponsorship/index.ts
@@ -61,7 +61,7 @@ async function getQuote(
   const quoteToken = Token.findByTicker('USDC')
 
   return await getExternalMatchQuote(config, {
-    useGasSponsorship: true, // Note that this is true by default
+    disableGasSponsorship: false, // Note that this is false by default
     refundNativeEth: false, // Note that this is false by default
     order: {
       base: baseToken.address,

--- a/examples/native-eth-gas-sponsorship/README.md
+++ b/examples/native-eth-gas-sponsorship/README.md
@@ -26,7 +26,7 @@ This example demonstrates how to execute trades with gas sponsorship enabled. Th
 
 Here's how it works:
 
-1. Gets a quote for a match with `useGasSponsorship` set to true, `refundNativeEth` set to true, and the `refundAddress` set.
+1. Gets a quote for a match with `disableGasSponsorship` set to false, `refundNativeEth` set to true, and the `refundAddress` set.
 2. Assembles the quote.
 3. The bundle includes routing through the gas sponsorship contract
 4. At the end of the transaction, the gas sponsorship contract will refund the gas costs to the configured address. You should see the address receive a transfer of ETH approximately equivalent to the gas costs of the transaction.

--- a/examples/native-eth-gas-sponsorship/index.ts
+++ b/examples/native-eth-gas-sponsorship/index.ts
@@ -61,7 +61,7 @@ async function getQuote(
   const quoteToken = Token.findByTicker('USDC')
 
   return await getExternalMatchQuote(config, {
-    useGasSponsorship: true, // Note that this is true by default
+    disableGasSponsorship: false, // Note that this is false by default
     refundAddress: refundAddress,
     refundNativeEth: true,
     order: {

--- a/packages/core/src/actions/getExternalMatchBundle.ts
+++ b/packages/core/src/actions/getExternalMatchBundle.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
 import { toHex, zeroAddress } from 'viem'
 import {
-  GAS_SPONSORSHIP_PARAM,
+  DISABLE_GAS_SPONSORSHIP_PARAM,
   REFUND_ADDRESS_PARAM,
   REFUND_NATIVE_ETH_PARAM,
   RENEGADE_API_KEY_HEADER,
@@ -19,6 +19,7 @@ export type GetExternalMatchBundleParameters = {
   order: ExternalOrder
   doGasEstimation?: boolean
   receiverAddress?: `0x${string}`
+  // TODO: Replace this with `disableGasSponsorship` to match API parameter name
   useGasSponsorship?: boolean
   refundAddress?: `0x${string}`
   refundNativeEth?: boolean
@@ -65,7 +66,7 @@ export async function getExternalMatchBundle(
 
   let url = config.getBaseUrl(REQUEST_EXTERNAL_MATCH_ROUTE)
   const searchParams = new URLSearchParams({
-    [GAS_SPONSORSHIP_PARAM]: useGasSponsorship.toString(),
+    [DISABLE_GAS_SPONSORSHIP_PARAM]: (!useGasSponsorship).toString(),
     [REFUND_ADDRESS_PARAM]: refundAddress,
     [REFUND_NATIVE_ETH_PARAM]: refundNativeEth.toString(),
   })

--- a/packages/core/src/actions/getExternalMatchQuote.ts
+++ b/packages/core/src/actions/getExternalMatchQuote.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
 import { toHex, zeroAddress } from 'viem'
 import {
-  GAS_SPONSORSHIP_PARAM,
+  DISABLE_GAS_SPONSORSHIP_PARAM,
   REFUND_ADDRESS_PARAM,
   REFUND_NATIVE_ETH_PARAM,
   RENEGADE_API_KEY_HEADER,
@@ -18,7 +18,7 @@ import { postWithSymmetricKey } from '../utils/http.js'
 export type GetExternalMatchQuoteParameters = {
   order: ExternalOrder
   doGasEstimation?: boolean
-  useGasSponsorship?: boolean
+  disableGasSponsorship?: boolean
   refundAddress?: `0x${string}`
   refundNativeEth?: boolean
 }
@@ -41,7 +41,7 @@ export async function getExternalMatchQuote(
       minFillSize = BigInt(0),
     },
     doGasEstimation,
-    useGasSponsorship = true,
+    disableGasSponsorship = false,
     refundAddress = zeroAddress,
     refundNativeEth = false,
   } = parameters
@@ -66,7 +66,7 @@ export async function getExternalMatchQuote(
 
   let url = config.getBaseUrl(REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE)
   const searchParams = new URLSearchParams({
-    [GAS_SPONSORSHIP_PARAM]: useGasSponsorship.toString(),
+    [DISABLE_GAS_SPONSORSHIP_PARAM]: disableGasSponsorship.toString(),
     [REFUND_ADDRESS_PARAM]: refundAddress,
     [REFUND_NATIVE_ETH_PARAM]: refundNativeEth.toString(),
   })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -221,8 +221,8 @@ export const REQUEST_EXTERNAL_MATCH_QUOTE_ROUTE = '/matching-engine/quote'
 export const ASSEMBLE_EXTERNAL_MATCH_ROUTE =
   '/matching-engine/assemble-external-match'
 
-/// The query parameter for using gas sponsorship
-export const GAS_SPONSORSHIP_PARAM = 'use_gas_sponsorship'
+/// The query parameter for disabling gas sponsorship
+export const DISABLE_GAS_SPONSORSHIP_PARAM = 'disable_gas_sponsorship'
 /// The query parameter for the gas sponsorship refund address
 export const REFUND_ADDRESS_PARAM = 'refund_address'
 /// The query parameter for whether to refund via native ETH

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: ^2.0.0
         version: 2.20.0(typescript@5.5.4)(zod@3.23.8)
 
-  examples/gas-sponsorship:
+  examples/in-kind-gas-sponsorship:
     dependencies:
       '@renegade-fi/core':
         specifier: workspace:*
@@ -73,7 +73,7 @@ importers:
         specifier: ^5.3.3
         version: 5.5.4
 
-  examples/in-kind-gas-sponsorship:
+  examples/native-eth-gas-sponsorship:
     dependencies:
       '@renegade-fi/core':
         specifier: workspace:*


### PR DESCRIPTION
This PR updates the SDK to using the `omit_gas_sponsorship` param instead of the now-deprecated `use_gas_sponsorship`.

### Testing
- [x] All examples run as expected