### PR TITLE
react: temp disable unsubscribing ws topics

### DIFF
--- a/packages/react/src/hooks/useOrderHistoryWebSocket.ts
+++ b/packages/react/src/hooks/useOrderHistoryWebSocket.ts
@@ -81,21 +81,6 @@ export function useOrderHistoryWebSocket(
     const symmetricKey = getSymmetricKey(config)
     const message = createSignedWebSocketRequest(config, symmetricKey, body)
     sendJsonMessage(message)
-
-    // Cleanup: unsubscribe the OLD wallet ID
-    return () => {
-      // Ensure that we have a valid wallet id to unsubscribe
-      if (!currentWalletId || readyState !== ReadyState.OPEN) return
-
-      // Unsubscribe from wallet's order updates
-      const body = {
-        method: 'unsubscribe' as const,
-        topic: WS_WALLET_ORDERS_ROUTE(currentWalletId),
-      } as const
-
-      const message = createSignedWebSocketRequest(config, symmetricKey, body)
-      sendJsonMessage(message)
-    }
   }, [
     enabled,
     walletId,

--- a/packages/react/src/hooks/useTaskHistoryWebSocket.ts
+++ b/packages/react/src/hooks/useTaskHistoryWebSocket.ts
@@ -81,24 +81,6 @@ export function useTaskHistoryWebSocket(
     )
 
     sendJsonMessage(subscriptionMessage)
-
-    // Cleanup: unsubscribe the OLD wallet ID
-    return () => {
-      // Ensure that we have a valid wallet id to unsubscribe
-      if (!currentWalletId || readyState !== ReadyState.OPEN) return
-
-      const unsubscriptionBody = {
-        method: 'unsubscribe',
-        topic: WS_TASK_HISTORY_ROUTE(currentWalletId),
-      } as const
-
-      const unsubscriptionMessage = createSignedWebSocketRequest(
-        config,
-        symmetricKey,
-        unsubscriptionBody,
-      )
-      sendJsonMessage(unsubscriptionMessage)
-    }
   }, [
     enabled,
     walletId,

--- a/packages/react/src/hooks/useWalletWebSocket.ts
+++ b/packages/react/src/hooks/useWalletWebSocket.ts
@@ -79,24 +79,6 @@ export function useWalletWebsocket(parameters: UseWalletParameters = {}) {
       body,
     )
     sendJsonMessage(subscriptionMessage)
-
-    // Cleanup: unsubscribe the OLD wallet ID
-    return () => {
-      // Ensure that we have a valid wallet id to unsubscribe
-      if (!currentWalletId || readyState !== ReadyState.OPEN) return
-
-      const unsubscriptionBody = {
-        method: 'unsubscribe',
-        topic: WALLET_ROUTE(currentWalletId),
-      } as const
-
-      const unsubscriptionMessage = createSignedWebSocketRequest(
-        config,
-        symmetricKey,
-        unsubscriptionBody,
-      )
-      sendJsonMessage(unsubscriptionMessage)
-    }
   }, [
     enabled,
     walletId,


### PR DESCRIPTION
### Purpose
This PR temporarily disables unsubscribing from topics in WebSockets. Because each hook invocation uses the same WebSocket connection, we cannot simply unsubscribe on unmount as a different invocation of the same hook may be using the connection. Therefore, we need a layer that keeps track of hook invocations and unsubscribes from topics iff there are no more hooks using the connection. This is not urgent, so we are reverting to old behavior for the time being.

### Testing
- [x] Tested locally
- [ ] Test in testnet