### PR TITLE
core: token: add convert to decimal helper

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.4
+  - @renegade-fi/node@0.5.8
+
 ## 1.1.3
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.4
+  - @renegade-fi/node@0.5.8
+
 ## 0.1.3
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.3",
+    "version": "0.1.4",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.4
+  - @renegade-fi/node@0.5.8
+
 ## 0.0.6
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.6",
+    "version": "0.0.7",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.6.4
+
+### Patch Changes
+
+- core: token: add convert to decimal helper
+
 ## 0.6.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/types/token.ts
+++ b/packages/core/src/types/token.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { type Address, isHex, zeroAddress } from 'viem'
+import { type Address, formatUnits, isHex, zeroAddress } from 'viem'
 import type { Exchange } from './wallet.js'
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -128,6 +128,12 @@ export class Token {
 
   isStablecoin(): boolean {
     return STABLECOINS.includes(this.ticker)
+  }
+
+  /// Converts the amount of the token, accounting for the
+  /// associated number of decimals.
+  convertToDecimal(amount: bigint): number {
+    return Number(formatUnits(amount, this.decimals))
   }
 
   static findByTicker(ticker: string): Token {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.5.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.4
+
 ## 0.5.7
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.5.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.4
+
 ## 0.5.6
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.4
+
 ## 0.4.6
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
### Purpose
This PR adds the TS analog of the `convert_to_decimal` method that exists [in Rust](https://github.com/renegade-fi/renegade/blob/4ddd79352aaab61328e1437e2b85da47c5ddd6ac/common/src/types/token.rs#L190).

### Testing
- [ ] Tested locally
- [ ] Test in testnet