### PR TITLE
core: utils: http: Add `x-renegade-sdk-version` to headers

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -4,6 +4,8 @@ import type { Address } from 'viem'
 export const RENEGADE_AUTH_HEADER_NAME = 'x-renegade-auth'
 /// Header name for the expiration timestamp of a signature
 export const RENEGADE_SIG_EXPIRATION_HEADER_NAME = 'x-renegade-auth-expiration'
+/// Header name for the Renegade SDK version
+export const RENEGADE_SDK_VERSION_HEADER = 'x-renegade-sdk-version'
 /// The Renegade API key header
 export const RENEGADE_API_KEY_HEADER = 'x-renegade-api-key'
 /// The message used to derive the wallet's root key

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import invariant from 'tiny-invariant'
 import {
   RENEGADE_AUTH_HEADER_NAME,
+  RENEGADE_SDK_VERSION_HEADER,
   RENEGADE_SIG_EXPIRATION_HEADER_NAME,
   SIG_EXPIRATION_BUFFER_MS,
 } from '../constants.js'
@@ -9,6 +10,9 @@ import type { BaseConfig, Config, RenegadeConfig } from '../createConfig.js'
 import { BaseError } from '../errors/base.js'
 import { parseBigJSON } from './bigJSON.js'
 import type { AuthType } from './websocket.js'
+
+import pkg from '../../package.json' assert { type: 'json' }
+const { version: sdkVersion } = pkg
 
 export async function postRelayerRaw(url: string, body: any, headers = {}) {
   try {
@@ -251,9 +255,11 @@ export function addExpiringAuthToHeaders(
 ): Record<string, string> {
   // Add a timestamp
   const expirationTs = Date.now() + expiration
+  const versionString = `typescript-v${sdkVersion}`
   const headersWithExpiration = {
     ...headers,
     [RENEGADE_SIG_EXPIRATION_HEADER_NAME]: expirationTs.toString(),
+    [RENEGADE_SDK_VERSION_HEADER]: versionString,
   }
 
   // Add the signature

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
 
         // Language and environment
         "moduleResolution": "NodeNext",
+        "resolveJsonModule": true,
         "module": "NodeNext",
         "target": "ES2021", // Setting this to `ES2021` enables native support for `Node v16+`: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping.
         "lib": [


### PR DESCRIPTION
### Purpose
This PR adds an SDK version header to the typescript SDK requests. We use the `@renegade-fi/core` version for this.

### Testing
- [x] Tested with mock requests