### PR TITLE
wasm: external_api: remove sponsorship info from assembly req

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.6
+  - @renegade-fi/node@0.5.10
+
 ## 1.1.5
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.6
+  - @renegade-fi/node@0.5.10
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.5",
+    "version": "0.1.6",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.6
+  - @renegade-fi/node@0.5.10
+
 ## 0.0.8
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.8",
+    "version": "0.0.9",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.6.6
+
+### Patch Changes
+
+- remove gas sponsorship info from assembly request
+
 ## 0.6.5
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -140,21 +140,6 @@ export function assemble_external_match(do_gas_estimation: boolean, updated_orde
 * @param {string} symmetric_key
 * @returns {Promise<any>}
 */
-export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {Function} sign_message
-* @returns {Promise<any>}
-*/
-export function generate_wallet_secrets(sign_message: Function): Promise<any>;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
 export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
 /**
 * @param {string} seed
@@ -180,6 +165,21 @@ export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: 
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {Function} sign_message
+* @returns {Promise<any>}
+*/
+export function generate_wallet_secrets(sign_message: Function): Promise<any>;
 /**
 * @param {string} path
 * @param {any} headers

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.6.5'
+export const version = '0.6.6'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.5.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.6
+
 ## 0.5.9
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.5.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.6
+
 ## 0.5.8
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.6
+
 ## 0.4.8
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "renegade-utils"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "alloy-primitives 0.3.3",
  "ark-bn254",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "renegade-utils"
 description = "Utility functions from the Renegade relayer"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 [lib]

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -2,7 +2,7 @@
 
 use super::types::{
     ApiOrder, ApiOrderType, ApiPrivateKeychain, ApiWallet, SignedExternalQuote,
-    SignedGasSponsorshipInfo, SponsoredQuoteResponse,
+    SponsoredQuoteResponse,
 };
 use crate::{
     circuit_types::{balance::Balance, fixed_point::FixedPoint, order::OrderSide, Amount},
@@ -735,7 +735,7 @@ pub fn new_external_quote_request(
 
 /// The request type for assembling an external match, potentially with gas sponsorship
 #[derive(Clone, Serialize, Deserialize)]
-pub struct AssembleSponsoredMatchRequest {
+pub struct AssembleExternalMatchRequest {
     /// The signed external match quote
     pub signed_quote: SignedExternalQuote,
     /// Whether or not to include gas estimation in the response
@@ -747,9 +747,6 @@ pub struct AssembleSponsoredMatchRequest {
     /// The updated order
     #[serde(default)]
     pub updated_order: Option<ExternalOrder>,
-    /// The signed gas sponsorship info associated with the quote,
-    /// if sponsorship was requested
-    pub gas_sponsorship_info: Option<SignedGasSponsorshipInfo>,
 }
 
 #[wasm_bindgen]
@@ -773,19 +770,16 @@ pub fn assemble_external_match(
     };
 
     let SponsoredQuoteResponse {
-        quote,
-        signature,
-        gas_sponsorship_info,
+        quote, signature, ..
     } = serde_json::from_str(sponsored_quote_response)?;
 
     let signed_quote = SignedExternalQuote { quote, signature };
 
-    let req = AssembleSponsoredMatchRequest {
+    let req = AssembleExternalMatchRequest {
         do_gas_estimation,
         receiver_address,
         updated_order,
         signed_quote,
-        gas_sponsorship_info,
     };
 
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))

--- a/wasm/src/external_api/types.rs
+++ b/wasm/src/external_api/types.rs
@@ -354,6 +354,7 @@ pub struct SignedGasSponsorshipInfo {
     /// The signed gas sponsorship info
     pub gas_sponsorship_info: GasSponsorshipInfo,
     /// The auth server's signature over the sponsorship info
+    #[deprecated(since = "0.0.2", note = "Gas sponsorship info is no longer signed")]
     pub signature: String,
 }
 


### PR DESCRIPTION
This PR removes the `gas_sponsorship_info` field from the `AssembleExternalMatchRequest`, as it is no longer needed by the API.

### Testing
- [x] Ran all SDK examples, asserting they behave as expected