### PR TITLE
core: utils: websocketWaiter: catch prefetch errors

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.7
+  - @renegade-fi/node@0.5.11
+
 ## 1.1.6
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.7
+  - @renegade-fi/node@0.5.11
+
 ## 0.1.6
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.6",
+    "version": "0.1.7",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.7
+  - @renegade-fi/node@0.5.11
+
 ## 0.0.9
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.9",
+    "version": "0.0.10",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.6.7
+
+### Patch Changes
+
+- catch errors in websocket waiter prefetch
+
 ## 0.6.6
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/utils/websocketWaiter.ts
+++ b/packages/core/src/utils/websocketWaiter.ts
@@ -88,13 +88,22 @@ export async function websocketWaiter<T>(
     }
 
     if (params.prefetch) {
-      params.prefetch().then((result) => {
-        if (result) {
-          promiseSettled = true
-          ws.close()
-          resolve(result)
-        }
-      })
+      params
+        .prefetch()
+        .then((result) => {
+          if (result) {
+            promiseSettled = true
+            ws.close()
+            resolve(result)
+          }
+        })
+        .catch((error) => {
+          if (!promiseSettled) {
+            promiseSettled = true
+            ws.close()
+            reject(error)
+          }
+        })
     }
   })
 }

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.6.6'
+export const version = '0.6.7'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.5.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.7
+
 ## 0.5.10
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/node",
   "description": "Node.js library for Renegade",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.5.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.7
+
 ## 0.5.9
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.6.7
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
This PR fixes up the `websocketWaiter` utility to properly catch errors thrown in the `prefetch` function. Since this is a Promise that is not directly `awaited`, any errors thrown in it would not be caught by `try/catch` blocks wrapping the top-level `websocketWaiter` Promise.