### PR TITLE
wasm, core: make update order path compatible with external keychains

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+  - @renegade-fi/node@0.5.16
+
 ## 1.1.11
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.11",
+    "version": "1.1.12",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+  - @renegade-fi/node@0.5.16
+
 ## 0.1.11
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.11",
+    "version": "0.1.12",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/node@0.5.16
+
 ## 0.0.5
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.5",
+    "version": "0.0.6",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+  - @renegade-fi/node@0.5.16
+
 ## 0.0.14
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.14",
+    "version": "0.0.15",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.7.2
+
+### Patch Changes
+
+- wasm, core: make update order path compatible with external keychains
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -1,6 +1,55 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {Function} sign_message
+* @returns {Promise<any>}
+*/
+export function generate_wallet_secrets(sign_message: Function): Promise<any>;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
+/**
+* @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function get_pk_root(seed: string, nonce: bigint): any;
+/**
+* @param {string | undefined} [seed]
+* @param {bigint | undefined} [nonce]
+* @param {string | undefined} [public_key]
+* @returns {any[]}
+*/
+export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: string): any[];
+/**
+* @param {string} seed
+* @returns {any}
+*/
+export function get_symmetric_key(seed: string): any;
+/**
 * @param {string} seed
 * @returns {any}
 */
@@ -88,7 +137,7 @@ export function new_order_in_matching_pool(seed: string | undefined, wallet_str:
 */
 export function cancel_order(seed: string | undefined, wallet_str: string, order_id: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
-* @param {string} seed
+* @param {string | undefined} seed
 * @param {string} wallet_str
 * @param {string} id
 * @param {string} base_mint
@@ -98,9 +147,11 @@ export function cancel_order(seed: string | undefined, wallet_str: string, order
 * @param {string} worst_case_price
 * @param {string} min_fill_size
 * @param {boolean} allow_external_matches
-* @returns {any}
+* @param {string | undefined} [new_public_key]
+* @param {Function | undefined} [sign_message]
+* @returns {Promise<any>}
 */
-export function update_order(seed: string, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean): any;
+export function update_order(seed: string | undefined, wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string, worst_case_price: string, min_fill_size: string, allow_external_matches: boolean, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string} base_mint
 * @param {string} quote_mint
@@ -131,55 +182,6 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 * @returns {any}
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, sponsored_quote_response: string, receiver_address: string): any;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
-export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function get_pk_root(seed: string, nonce: bigint): any;
-/**
-* @param {string | undefined} [seed]
-* @param {bigint | undefined} [nonce]
-* @param {string | undefined} [public_key]
-* @returns {any[]}
-*/
-export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: string): any[];
-/**
-* @param {string} seed
-* @returns {any}
-*/
-export function get_symmetric_key(seed: string): any;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
-export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {Function} sign_message
-* @returns {Promise<any>}
-*/
-export function generate_wallet_secrets(sign_message: Function): Promise<any>;
 /**
 * @param {string} path
 * @param {any} headers

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.7.1";
+export const version = '0.7.2'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.5.16
+
+### Patch Changes
+
+- wasm, core: make update order path compatible with external keychains
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+
 ## 0.5.15
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.5.15",
+    "version": "0.5.16",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/src/clients/relayer/index.ts
+++ b/packages/node/src/clients/relayer/index.ts
@@ -20,6 +20,9 @@ import {
 } from "@renegade-fi/core/actions";
 import * as rustUtils from "../../../renegade-utils/index.js";
 
+/**
+ * The client for interacting with the Renegade relayer's admin API with an API key.
+ */
 export class AdminRelayerClient {
     readonly config: Config;
     readonly configv2: SDKConfig;
@@ -123,5 +126,14 @@ export class AdminRelayerClient {
      */
     async triggerSnapshot() {
         return triggerRelayerSnapshot(this.config);
+    }
+
+    /**
+     * Get the config
+     *
+     * TODO: Remove once we migrate to the SDK config
+     */
+    public getConfig() {
+        return this.config;
     }
 }

--- a/packages/node/src/clients/renegade/admin.ts
+++ b/packages/node/src/clients/renegade/admin.ts
@@ -7,6 +7,9 @@ import * as rustUtils from "../../../renegade-utils/index.js";
 import { RenegadeClient } from "./base.js";
 import type { ConstructorParams } from "./types.js";
 
+/**
+ * The client for interacting with the Renegade relayer's admin API, with a keychain.
+ */
 export class AdminRenegadeClient extends RenegadeClient {
     private readonly apiKey: string;
 

--- a/packages/node/src/clients/renegade/base.ts
+++ b/packages/node/src/clients/renegade/base.ts
@@ -4,6 +4,7 @@ import type {
     DepositParameters,
     RenegadeConfig,
     SDKConfig,
+    UpdateOrderParameters,
     WithdrawParameters,
 } from "@renegade-fi/core";
 import {
@@ -11,6 +12,8 @@ import {
     createExternalKeyConfig,
     getSDKConfig,
     getTaskQueue,
+    getWalletId,
+    updateOrder,
 } from "@renegade-fi/core";
 import {
     cancelOrder,
@@ -18,6 +21,7 @@ import {
     createWallet,
     deposit,
     getBackOfQueueWallet,
+    getTaskQueuePaused,
     getWalletFromRelayer,
     lookupWallet,
     payFees,
@@ -38,6 +42,9 @@ import {
 } from "../../actions/generateWalletSecrets.js";
 import type { ConstructorParams } from "./types.js";
 
+/**
+ * The client for interacting with the Renegade relayer with a keychain.
+ */
 export class RenegadeClient {
     readonly config: RenegadeConfig;
     readonly configv2: SDKConfig;
@@ -237,6 +244,10 @@ export class RenegadeClient {
         return createWallet(this.getConfig());
     }
 
+    getWalletId() {
+        return getWalletId(this.getConfig());
+    }
+
     // -- Balance Operations -- //
 
     async deposit(parameters: DepositParameters) {
@@ -297,6 +308,10 @@ export class RenegadeClient {
         return createOrder(this.getConfig(), parameters);
     }
 
+    async updateOrder(parameters: UpdateOrderParameters) {
+        return updateOrder(this.getConfig(), parameters);
+    }
+
     async cancelOrder(parameters: CancelOrderParameters) {
         return cancelOrder(this.getConfig(), parameters);
     }
@@ -305,6 +320,10 @@ export class RenegadeClient {
 
     async getTaskQueue() {
         return getTaskQueue(this.getConfig());
+    }
+
+    async getTaskQueuePaused() {
+        return getTaskQueuePaused(this.getConfig());
     }
 
     // --- Keychain Generation --- //
@@ -335,7 +354,10 @@ export class RenegadeClient {
 
     // -- Private -- //
 
-    protected getConfig() {
+    /**
+     * @internal
+     */
+    public getConfig() {
         return this.config;
     }
 }

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+  - @renegade-fi/token@0.0.5
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+
 ## 0.4.13
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.2
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",


### PR DESCRIPTION
### Purpose
This PR adds updateOrder, getWalletId, getTaskQueuePaused methods to the RenegadeClient. The `updateOrder` path had to be updated to be compatible with external keychains, this was done by copying code from `placeOrder` path as the signature generation steps are the same.

### Testing
- [x] Tested locally
- [x] Test in testnet