### PR TITLE
core, node: filter defaults when fetching wallet, catch error in prefetch

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+  - @renegade-fi/node@0.5.17
+
 ## 1.1.12
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+  - @renegade-fi/node@0.5.17
+
 ## 0.1.12
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.12",
+    "version": "0.1.13",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/node@0.5.17
+
 ## 0.0.6
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.6",
+    "version": "0.0.7",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+  - @renegade-fi/node@0.5.17
+
 ## 0.0.15
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.15",
+    "version": "0.0.16",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.7.3
+
+### Patch Changes
+
+- core, node: filter defaults when fetching wallet, catch error in prefetch
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/utils/websocket.ts
+++ b/packages/core/src/utils/websocket.ts
@@ -66,7 +66,7 @@ export class RelayerWebsocket {
         return this.oncloseCallback?.call(this.ws!, event);
     };
 
-    private handleError = async (event: Event) => {
+    private handleError = (event: Event) => {
         this.cleanup();
         return this.onerrorCallback?.call(this.ws!, event);
     };
@@ -117,7 +117,7 @@ export class RelayerWebsocket {
 
     public close(): void {
         if (!this.ws) {
-            throw new Error("WebSocket connection not open");
+            return;
         }
 
         const message = this.buildUnsubscriptionMessage();
@@ -131,7 +131,7 @@ export class RelayerWebsocket {
     // ---------------
 
     private request(message: SubscriptionMessage | UnsubscriptionMessage): void {
-        if (this.ws?.readyState === this.ws?.CLOSED || this.ws?.readyState === this.ws?.CLOSING) {
+        if (!this.ws || this.ws.readyState !== this.ws.OPEN) {
             throw new WebSocketRequestError({
                 body: message,
                 url: this.ws?.url || "",

--- a/packages/core/src/utils/websocketWaiter.ts
+++ b/packages/core/src/utils/websocketWaiter.ts
@@ -87,14 +87,24 @@ export async function websocketWaiter<T>(params: WebsocketWaiterParams): Promise
                 .then((result) => {
                     if (result) {
                         promiseSettled = true;
-                        ws.close();
+                        try {
+                            ws.close();
+                        } catch (_) {
+                            // If the WS is not open, this will throw an error.
+                            // This is fine, so we can ignore it.
+                        }
                         resolve(result);
                     }
                 })
                 .catch((error) => {
                     if (!promiseSettled) {
                         promiseSettled = true;
-                        ws.close();
+                        try {
+                            ws.close();
+                        } catch (_) {
+                            // If the WS is not open, this will throw an error.
+                            // This is fine, so we can ignore it.
+                        }
                         reject(error);
                     }
                 });

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.7.2'
+export const version = '0.7.3'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.5.17
+
+### Patch Changes
+
+- core, node: filter defaults when fetching wallet, catch error in prefetch
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+
 ## 0.5.16
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.5.16",
+    "version": "0.5.17",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/src/clients/renegade/base.ts
+++ b/packages/node/src/clients/renegade/base.ts
@@ -2,6 +2,8 @@ import type {
     CancelOrderParameters,
     CreateOrderParameters,
     DepositParameters,
+    GetBackOfQueueWalletParameters,
+    GetWalletFromRelayerParameters,
     RenegadeConfig,
     SDKConfig,
     UpdateOrderParameters,
@@ -210,12 +212,20 @@ export class RenegadeClient {
 
     // -- Wallet Operations -- //
 
-    async getWallet() {
-        return getWalletFromRelayer(this.getConfig());
+    async getWallet(
+        params: GetWalletFromRelayerParameters = {
+            filterDefaults: true,
+        },
+    ) {
+        return getWalletFromRelayer(this.getConfig(), params);
     }
 
-    async getBackOfQueueWallet() {
-        return getBackOfQueueWallet(this.getConfig());
+    async getBackOfQueueWallet(
+        params: GetBackOfQueueWalletParameters = {
+            filterDefaults: true,
+        },
+    ) {
+        return getBackOfQueueWallet(this.getConfig(), params);
     }
 
     async lookupWallet() {

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+  - @renegade-fi/token@0.0.6
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+
 ## 0.6.2
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+
 ## 0.4.14
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.3
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",


### PR DESCRIPTION
### Purpose
This PR filters default structs from the get-wallet response by default. We also handle errors thrown from tasks that fail immediately when prefetching their status.

### Testing
- [x] Tested locally
- [x] Test in testnet