### PR TITLE
node: allow config overriding in constructor

### DIFF
--- a/packages/node/src/clients/external-match/index.ts
+++ b/packages/node/src/clients/external-match/index.ts
@@ -43,8 +43,12 @@ export class ExternalMatchClient {
         chainId: number;
         apiKey: string;
         apiSecret: string;
+        overrides?: Partial<SDKConfig>;
     }) {
-        const configv2 = getSDKConfig(params.chainId);
+        const defaultConfig = getSDKConfig(params.chainId);
+        const configv2 = params.overrides
+            ? { ...defaultConfig, ...params.overrides }
+            : defaultConfig;
         this.configv2 = configv2;
         this.apiKey = params.apiKey;
         this.apiSecret = params.apiSecret;
@@ -60,32 +64,36 @@ export class ExternalMatchClient {
     /**
      * Create a new ExternalMatchClient for a given chain.
      *
-     * @param params.apiKey    – your API key
-     * @param params.apiSecret – your API secret
-     * @param params.chainId   – the chain ID
+     * @param params.apiKey    your API key
+     * @param params.apiSecret your API secret
+     * @param params.chainId   the chain ID
+     * @param params.overrides any SDKConfig field can be passed directly as an override
      */
     static new({
         apiKey,
         apiSecret,
         chainId,
+        overrides,
     }: {
         apiKey: string;
         apiSecret: string;
         chainId: number;
+        overrides?: Partial<SDKConfig>;
     }) {
         return new ExternalMatchClient({
             rustUtils,
             chainId,
             apiKey,
             apiSecret,
+            overrides,
         });
     }
 
     /**
      * Create a new ExternalMatchClient for Arbitrum Mainnet.
      *
-     * @param params.apiKey    – your API key
-     * @param params.apiSecret – your API secret
+     * @param params.apiKey    your API key
+     * @param params.apiSecret your API secret
      */
     static newArbitrumMainnetClient({
         apiKey,
@@ -105,8 +113,8 @@ export class ExternalMatchClient {
     /**
      * Create a new ExternalMatchClient for Arbitrum Sepolia.
      *
-     * @param params.apiKey    – your API key
-     * @param params.apiSecret – your API secret
+     * @param params.apiKey    your API key
+     * @param params.apiSecret your API secret
      */
     static newArbitrumSepoliaClient({
         apiKey,

--- a/packages/node/src/clients/relayer/index.ts
+++ b/packages/node/src/clients/relayer/index.ts
@@ -33,8 +33,12 @@ export class AdminRelayerClient {
     private constructor(params: {
         apiKey: string;
         chainId: number;
+        overrides?: Partial<SDKConfig>;
     }) {
-        const configv2 = getSDKConfig(params.chainId);
+        const defaultConfig = getSDKConfig(params.chainId);
+        const configv2 = params.overrides
+            ? { ...defaultConfig, ...params.overrides }
+            : defaultConfig;
         this.configv2 = configv2;
 
         this.config = createConfig({
@@ -50,24 +54,27 @@ export class AdminRelayerClient {
     /**
      * Create a new AdminRelayerClient
      *
-     * @param params.apiKey – the API key
-     * @param params.chainId – the chain ID
+     * @param params.apiKey     your API key
+     * @param params.chainId    the chain ID
+     * @param params.overrides  any SDKConfig field can be passed directly as an override
      */
     static new({
         apiKey,
         chainId,
+        overrides,
     }: {
         apiKey: string;
         chainId: number;
+        overrides?: Partial<SDKConfig>;
     }) {
-        return new AdminRelayerClient({ apiKey, chainId });
+        return new AdminRelayerClient({ apiKey, chainId, overrides });
     }
 
     /**
      * Assign an order to a matching pool
      *
-     * @param params.orderId - the order ID
-     * @param params.matchingPool - the matching pool address
+     * @param params.orderId        the order ID
+     * @param params.matchingPool   name of the matching pool
      */
     async assignOrder(params: AssignOrderParameters) {
         return assignOrder(this.config, params);
@@ -76,7 +83,7 @@ export class AdminRelayerClient {
     /**
      * Create a matching pool
      *
-     * @param params.matchingPool - the matching pool address
+     * @param params.matchingPool name of the matching pool
      */
     async createMatchingPool(params: CreateMatchingPoolParameters) {
         return createMatchingPool(this.config, params);
@@ -85,7 +92,7 @@ export class AdminRelayerClient {
     /**
      * Destroy a matching pool
      *
-     * @param params.matchingPool - the matching pool address
+     * @param params.matchingPool name of the matching pool
      */
     async destroyMatchingPool(params: DestroyMatchingPoolParameters) {
         return destroyMatchingPool(this.config, params);
@@ -93,8 +100,6 @@ export class AdminRelayerClient {
 
     /**
      * Get open orders managed by the relayer
-     *
-     * @param params.matchingPool - the matching pool address
      */
     async getOpenOrders(params: GetOpenOrdersParameters) {
         return getOpenOrders(this.config, params);

--- a/packages/node/src/clients/renegade/admin.ts
+++ b/packages/node/src/clients/renegade/admin.ts
@@ -1,4 +1,5 @@
 import { createConfig } from "@renegade-fi/core";
+import type { SDKConfig } from "@renegade-fi/core";
 import {
     type CreateOrderInMatchingPoolParameters,
     createOrderInMatchingPool,
@@ -25,19 +26,23 @@ export class AdminRenegadeClient extends RenegadeClient {
     /**
      * Create an admin client for any chain by seed.
      *
-     * @param params.chainId – the chain ID (e.g. CHAIN_IDS.ArbitrumMainnet)
-     * @param params.seed    – your 0x… seed
+     * @param params.chainId    the chain ID (e.g. CHAIN_IDS.ArbitrumMainnet)
+     * @param params.seed       your 0x… seed
+     * @param params.apiKey     your admin API key
+     * @param params.overrides  optional overrides for SDK config values
      */
     static override new({
         chainId,
         seed,
         apiKey,
+        overrides,
     }: {
         chainId: number;
         seed: `0x${string}`;
         apiKey: string;
+        overrides?: Partial<SDKConfig>;
     }): AdminRenegadeClient {
-        return new AdminRenegadeClient({ chainId, mode: "seed", seed, apiKey });
+        return new AdminRenegadeClient({ chainId, mode: "seed", seed, apiKey, overrides });
     }
 
     /**

--- a/packages/node/src/clients/renegade/base.ts
+++ b/packages/node/src/clients/renegade/base.ts
@@ -57,7 +57,10 @@ export class RenegadeClient {
      * @internal
      */
     protected constructor(params: ConstructorParams) {
-        const configv2 = getSDKConfig(params.chainId);
+        const defaultConfig = getSDKConfig(params.chainId);
+        const configv2 = params.overrides
+            ? { ...defaultConfig, ...params.overrides }
+            : defaultConfig;
         this.configv2 = configv2;
 
         if (params.mode === "seed") {
@@ -89,26 +92,29 @@ export class RenegadeClient {
     /**
      * Create a client for any chain by seed.
      *
-     * @param params.chainId – the chain ID (e.g. CHAIN_IDS.ArbitrumMainnet)
-     * @param params.seed    – your 0x… seed
+     * @param params.chainId    the chain ID (e.g. CHAIN_IDS.ArbitrumMainnet)
+     * @param params.seed       your 0x… seed
+     * @param params.overrides  any SDKConfig field can be passed directly as an override
      */
     static new({
         chainId,
         seed,
+        overrides,
     }: {
         chainId: number;
         seed: `0x${string}`;
+        overrides?: Partial<SDKConfig>;
     }): RenegadeClient {
-        return new RenegadeClient({ chainId, mode: "seed", seed });
+        return new RenegadeClient({ chainId, mode: "seed", seed, overrides });
     }
 
     /**
      * Create a client for any chain with an external keychain.
      *
-     * @param params.chainId       – the chain ID
-     * @param params.walletSecrets – symmetric key + wallet ID
-     * @param params.signMessage   – callback to sign auth messages
-     * @param params.publicKey     – your public key
+     * @param params.chainId        the chain ID
+     * @param params.walletSecrets  symmetric key + wallet ID
+     * @param params.signMessage    callback to sign auth messages
+     * @param params.publicKey      your public key
      */
     static newWithExternalKeychain({
         chainId,
@@ -133,7 +139,7 @@ export class RenegadeClient {
     /**
      * Arbitrum Mainnet client via seed.
      *
-     * @param params.seed – your 0x… seed
+     * @param params.seed your 0x… seed
      */
     static newArbMainnetClient({
         seed,
@@ -149,9 +155,9 @@ export class RenegadeClient {
     /**
      * Arbitrum Mainnet client with external keychain.
      *
-     * @param params.walletSecrets – symmetric key + wallet ID
-     * @param params.signMessage   – callback to sign auth messages
-     * @param params.publicKey     – your public key
+     * @param params.walletSecrets  symmetric key + wallet ID
+     * @param params.signMessage    callback to sign auth messages
+     * @param params.publicKey      your public key
      */
     static newArbMainnetClientWithKeychain({
         walletSecrets,
@@ -173,7 +179,7 @@ export class RenegadeClient {
     /**
      * Arbitrum Sepolia client via seed.
      *
-     * @param params.seed – your 0x… seed
+     * @param params.seed your 0x… seed
      */
     static newArbSepoliaClient({
         seed,
@@ -189,9 +195,9 @@ export class RenegadeClient {
     /**
      * Arbitrum Sepolia client with external keychain.
      *
-     * @param params.walletSecrets – symmetric key + wallet ID
-     * @param params.signMessage   – callback to sign auth messages
-     * @param params.publicKey     – your public key
+     * @param params.walletSecrets  symmetric key + wallet ID
+     * @param params.signMessage    callback to sign auth messages
+     * @param params.publicKey      your public key
      */
     static newArbSepoliaClientWithKeychain({
         walletSecrets,

--- a/packages/node/src/clients/renegade/types.ts
+++ b/packages/node/src/clients/renegade/types.ts
@@ -1,7 +1,9 @@
+import type { SDKConfig } from "@renegade-fi/core";
 import type { GeneratedSecrets } from "../../actions/generateWalletSecrets.js";
 
 type CommonParams = {
     chainId: number;
+    overrides?: Partial<SDKConfig>;
 };
 
 type SeedParams = CommonParams & {


### PR DESCRIPTION
### Purpose
This PR allows for environment specific variables to be overriden when constructing various clients.

### Example
```js
const client = AdminRelayerClient.new({
    chainId: CHAIN_ID,
    apiKey: RELAYER_ADMIN_KEY,
    overrides: {
        relayerUrl: "localhost",
    },
});
```

### Testing
- [x] Tested locally
- [ ] Test in testnet