### PR TITLE
core: constants: update chain-specific URLs

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+  - @renegade-fi/node@0.5.19
+
 ## 1.1.14
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.14",
+    "version": "1.1.15",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+  - @renegade-fi/node@0.5.19
+
 ## 0.1.14
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.14",
+    "version": "0.1.15",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.9
+
+### Patch Changes
+
+- @renegade-fi/node@0.5.19
+
 ## 0.0.8
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.8",
+    "version": "0.0.9",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+  - @renegade-fi/node@0.5.19
+
 ## 0.0.17
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.17",
+    "version": "0.0.18",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.7.5
+
+### Patch Changes
+
+- Migrate to chain-aware URLs
+
 ## 0.7.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.7.4",
+    "version": "0.7.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -36,11 +36,12 @@ export const HSE_URL_TESTNET = "https://testnet.historical-state.renegade.fi:300
 // Chain-Specific Constants
 ////////////////////////////////////////////////////////////////////////////////
 
-export const RELAYER_URL_ARBITRUM_ONE = "mainnet.cluster0.renegade.fi";
-export const RELAYER_URL_ARBITRUM_SEPOLIA = "testnet.cluster0.renegade.fi";
+export const RELAYER_URL_ARBITRUM_ONE = "arbitrum-one.relayer.renegade.fi";
+export const RELAYER_URL_ARBITRUM_SEPOLIA = "arbitrum-sepolia.relayer.renegade.fi";
 
-export const AUTH_SERVER_URL_ARBITRUM_ONE = "https://mainnet.auth-server.renegade.fi:3000";
-export const AUTH_SERVER_URL_ARBITRUM_SEPOLIA = "https://testnet.auth-server.renegade.fi:3000";
+export const AUTH_SERVER_URL_ARBITRUM_ONE = "https://arbitrum-one.auth-server.renegade.fi:3000";
+export const AUTH_SERVER_URL_ARBITRUM_SEPOLIA =
+    "https://arbitrum-sepolia.auth-server.renegade.fi:3000";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Deployed Contracts

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.7.4'
+export const version = '0.7.5'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.5.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+
 ## 0.5.18
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.5.18",
+    "version": "0.5.19",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+  - @renegade-fi/token@0.0.8
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+
 ## 0.6.4
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+
 ## 0.4.16
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.16",
+    "version": "0.4.17",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.5
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",


### PR DESCRIPTION
This PR migrates the URLs of chain-specific resources (relayer, auth server) to the new naming convention.

I asserted that these are the correct URLs by copying them into Postman and invoking the associated resource's healthcheck endpoint.