### PR TITLE
price-reporter, core, token: use canonical exchange for getPrice

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.7
+  - @renegade-fi/node@0.5.21
+
 ## 1.1.16
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.16",
+    "version": "1.1.17",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.7
+  - @renegade-fi/node@0.5.21
+
 ## 0.1.16
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.16",
+    "version": "0.1.17",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.11
+
+### Patch Changes
+
+- @renegade-fi/node@0.5.21
+
 ## 0.0.10
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.10",
+    "version": "0.0.11",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.7
+  - @renegade-fi/node@0.5.21
+
 ## 0.0.19
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.19",
+    "version": "0.0.20",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.7.7
+
+### Patch Changes
+
+- price-reporter, core, token: use canonical exchange for getPrice
+
 ## 0.7.6
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.7.6",
+    "version": "0.7.7",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -1,7 +1,7 @@
 import type { Hex } from "viem";
 import type { Order } from "./order.js";
 
-export type Exchange = "binance" | "coinbase" | "kraken" | "okx";
+export type Exchange = "binance" | "coinbase" | "kraken" | "okx" | "renegade";
 
 export type NetworkOrder = {
     id: string;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.7.6'
+export const version = '0.7.7'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.5.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.7
+
 ## 0.5.20
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.5.20",
+    "version": "0.5.21",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @renegade-fi/price-reporter
 
+## 0.0.10
+
+### Patch Changes
+
+- price-reporter, core, token: use canonical exchange for getPrice
+- Updated dependencies
+  - @renegade-fi/token@0.0.10
+  - @renegade-fi/core@0.7.7
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/price-reporter/src/client.ts
+++ b/packages/price-reporter/src/client.ts
@@ -1,9 +1,15 @@
-import { CHAIN_IDS, getSDKConfig } from "@renegade-fi/core";
 import { getDefaultQuoteToken } from "@renegade-fi/token";
 import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
 import { ResultAsync, errAsync, fromThrowable } from "neverthrow";
-import { ERR_INVALID_URL, ERR_NO_PRICE_REPORTER_URL, PRICE_REPORTER_ROUTE } from "./constants.js";
+import {
+    ENVIRONMENTS,
+    ERR_INVALID_URL,
+    ERR_NO_PRICE_REPORTER_URL,
+    type Environment,
+    PRICE_REPORTER_ROUTE,
+    RENEGADE_EXCHANGE,
+} from "./constants.js";
 import { HttpError, PriceReporterError } from "./error.js";
 
 /**
@@ -12,28 +18,24 @@ import { HttpError, PriceReporterError } from "./error.js";
 export class PriceReporterClient {
     constructor(private readonly baseUrl: string) {}
 
-    static new(chainId: number) {
-        const config = getSDKConfig(chainId);
-        return new PriceReporterClient(`https://${config.priceReporterUrl}:3000`);
+    static new(env: Environment) {
+        return new PriceReporterClient(`https://${env}.price-reporter.renegade.fi:3000`);
     }
 
-    static newArbitrumOneClient() {
-        const config = getSDKConfig(CHAIN_IDS.ArbitrumOne);
-        return new PriceReporterClient(`https://${config.priceReporterUrl}:3000`);
+    static newMainnetClient() {
+        return PriceReporterClient.new(ENVIRONMENTS.Mainnet);
     }
 
-    static newArbitrumSepoliaClient() {
-        const config = getSDKConfig(CHAIN_IDS.ArbitrumSepolia);
-        return new PriceReporterClient(`https://${config.priceReporterUrl}:3000`);
+    static newTestnetClient() {
+        return PriceReporterClient.new(ENVIRONMENTS.Testnet);
     }
 
     /**
      * Get the current Renegade execution price for a specific token
      */
     public getPrice(mint: `0x${string}`): Promise<number> {
-        const exchange = "binance";
-        const quote = getDefaultQuoteToken(exchange).address;
-        return this.getPriceByTopic(exchange, mint, quote);
+        const quote = getDefaultQuoteToken(RENEGADE_EXCHANGE).address;
+        return this.getPriceByTopic(RENEGADE_EXCHANGE, mint, quote);
     }
 
     /**
@@ -42,9 +44,8 @@ export class PriceReporterClient {
      * @returns the price or an error
      */
     public getPriceResult(mint: `0x${string}`): ResultAsync<number, PriceReporterError> {
-        const exchange = "binance";
-        const quote = getDefaultQuoteToken(exchange).address;
-        return this.getPriceByTopicResult(exchange, mint, quote);
+        const quote = getDefaultQuoteToken(RENEGADE_EXCHANGE).address;
+        return this.getPriceByTopicResult(RENEGADE_EXCHANGE, mint, quote);
     }
 
     /**

--- a/packages/price-reporter/src/constants.ts
+++ b/packages/price-reporter/src/constants.ts
@@ -18,3 +18,21 @@ const PRICE_REPORTER_TOPIC = (exchange: string, base: string, quote: string) =>
  */
 export const PRICE_REPORTER_ROUTE = (exchange: string, base: string, quote: string) =>
     `/price/${PRICE_REPORTER_TOPIC(exchange, base, quote)}`;
+
+/**
+ * The environment to fetch the price from
+ */
+export const ENVIRONMENTS = {
+    Mainnet: "mainnet",
+    Testnet: "testnet",
+} as const;
+
+/**
+ * The type for the environment
+ */
+export type Environment = (typeof ENVIRONMENTS)[keyof typeof ENVIRONMENTS];
+
+/**
+ * The alias for the canonical exchange
+ */
+export const RENEGADE_EXCHANGE = "renegade";

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.7
+
 ## 0.6.6
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.6",
+    "version": "0.6.7",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.7
+
 ## 0.4.18
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.18",
+    "version": "0.4.19",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/token
 
+## 0.0.10
+
+### Patch Changes
+
+- price-reporter, core, token: use canonical exchange for getPrice
+- Updated dependencies
+  - @renegade-fi/core@0.7.7
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",

--- a/packages/token/src/index.ts
+++ b/packages/token/src/index.ts
@@ -212,7 +212,9 @@ export function getDefaultQuoteToken(exchange: Exchange): Token {
                 { kraken: "USD" },
             );
         case "okx":
-            return Token.findByTicker("USDT");
+            return Token.fromTicker("USDT");
+        case "renegade":
+            return Token.fromTicker("USDC");
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR sets the exchange to "renegade" when fetching prices using `getPrice`.

### Testing
- [ ] Tested locally
- [ ] Test in testnet