### PR TITLE
wasm; core: withdraw: add Base-specific withdrawal auth

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+  - @renegade-fi/node@0.6.0
+
 ## 1.1.20
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.20",
+    "version": "1.1.21",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+  - @renegade-fi/node@0.6.0
+
 ## 0.1.20
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.20",
+    "version": "0.1.21",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/node@0.6.0
+
 ## 0.0.14
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.14",
+    "version": "0.0.15",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.24
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+  - @renegade-fi/node@0.6.0
+
 ## 0.0.23
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.23",
+    "version": "0.0.24",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.8.0
+
+### Minor Changes
+
+- add Base-specific withdrawal logic & client
+
 ## 0.7.10
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.7.10",
+    "version": "0.8.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/actions/withdraw.ts
+++ b/packages/core/src/actions/withdraw.ts
@@ -1,6 +1,6 @@
 import invariant from "tiny-invariant";
 import { type Address, toHex } from "viem";
-import { WITHDRAW_BALANCE_ROUTE } from "../constants.js";
+import { CHAIN_SPECIFIERS, WITHDRAW_BALANCE_ROUTE } from "../constants.js";
 import type { RenegadeConfig } from "../createConfig.js";
 import { stringifyForWasm } from "../utils/bigJSON.js";
 import { postRelayerWithAuth } from "../utils/http.js";
@@ -39,7 +39,10 @@ export async function withdraw(
         invariant(seed !== undefined, "Seed is required for internal key type");
     }
 
+    const chain = CHAIN_SPECIFIERS[config.chainId];
+
     const body = await utils.withdraw(
+        chain,
         seed,
         stringifyForWasm(wallet),
         mint,

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -4,6 +4,7 @@ import {
     AUTH_SERVER_URL_BASE_SEPOLIA,
     CHAIN_IDS,
     CHAIN_ID_TO_ENVIRONMENT,
+    CHAIN_SPECIFIERS,
     type ChainId,
     DARKPOOL_ADDRESS_ARBITRUM_ONE,
     DARKPOOL_ADDRESS_ARBITRUM_SEPOLIA,
@@ -36,7 +37,7 @@ export interface SDKConfig {
 export const CONFIGS: Record<ChainId, SDKConfig> = {
     [CHAIN_IDS.ArbitrumOne]: {
         id: CHAIN_IDS.ArbitrumOne,
-        chainSpecifier: "arbitrum-one",
+        chainSpecifier: CHAIN_SPECIFIERS[CHAIN_IDS.ArbitrumOne],
         hseBaseUrl: HSE_URL_MAINNET,
         darkpoolAddress: DARKPOOL_ADDRESS_ARBITRUM_ONE,
         relayerUrl: RELAYER_URL_ARBITRUM_ONE,
@@ -47,7 +48,7 @@ export const CONFIGS: Record<ChainId, SDKConfig> = {
     },
     [CHAIN_IDS.ArbitrumSepolia]: {
         id: CHAIN_IDS.ArbitrumSepolia,
-        chainSpecifier: "arbitrum-sepolia",
+        chainSpecifier: CHAIN_SPECIFIERS[CHAIN_IDS.ArbitrumSepolia],
         hseBaseUrl: HSE_URL_TESTNET,
         darkpoolAddress: DARKPOOL_ADDRESS_ARBITRUM_SEPOLIA,
         relayerUrl: RELAYER_URL_ARBITRUM_SEPOLIA,
@@ -58,7 +59,7 @@ export const CONFIGS: Record<ChainId, SDKConfig> = {
     },
     [CHAIN_IDS.BaseSepolia]: {
         id: CHAIN_IDS.BaseSepolia,
-        chainSpecifier: "base-sepolia",
+        chainSpecifier: CHAIN_SPECIFIERS[CHAIN_IDS.BaseSepolia],
         hseBaseUrl: HSE_URL_TESTNET,
         darkpoolAddress: DARKPOOL_ADDRESS_BASE_SEPOLIA,
         relayerUrl: RELAYER_URL_BASE_SEPOLIA,

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,6 +23,13 @@ export const CHAIN_IDS = {
 
 export type ChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
 
+export const CHAIN_SPECIFIERS = {
+    [CHAIN_IDS.ArbitrumOne]: "arbitrum-one",
+    [CHAIN_IDS.ArbitrumSepolia]: "arbitrum-sepolia",
+    [CHAIN_IDS.BaseSepolia]: "base-sepolia",
+} as const;
+export type ChainSpecifier = (typeof CHAIN_SPECIFIERS)[keyof typeof CHAIN_SPECIFIERS];
+
 export const ENVIRONMENT = {
     Mainnet: "mainnet",
     Testnet: "testnet",

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -1,6 +1,29 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
 * @param {string} seed
 * @param {bigint} nonce
 * @returns {any}
@@ -24,44 +47,6 @@ export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: 
 * @returns {any}
 */
 export function get_symmetric_key(seed: string): any;
-/**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
-export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {Function} sign_message
-* @returns {Promise<any>}
-*/
-export function generate_wallet_secrets(sign_message: Function): Promise<any>;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
-export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
 /**
 * @param {string} seed
 * @returns {any}
@@ -97,6 +82,7 @@ export function wallet_id(seed: string): any;
 */
 export function deposit(seed: string | undefined, wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
+* @param {string} chain
 * @param {string | undefined} seed
 * @param {string} wallet_str
 * @param {string} mint
@@ -106,7 +92,7 @@ export function deposit(seed: string | undefined, wallet_str: string, from_addr:
 * @param {Function | undefined} [sign_message]
 * @returns {Promise<any>}
 */
-export function withdraw(seed: string | undefined, wallet_str: string, mint: string, amount: string, destination_addr: string, new_public_key?: string, sign_message?: Function): Promise<any>;
+export function withdraw(chain: string, seed: string | undefined, wallet_str: string, mint: string, amount: string, destination_addr: string, new_public_key?: string, sign_message?: Function): Promise<any>;
 /**
 * @param {string | undefined} seed
 * @param {string} wallet_str
@@ -195,3 +181,18 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 * @returns {any}
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, sponsored_quote_response: string, receiver_address: string): any;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {Function} sign_message
+* @returns {Promise<any>}
+*/
+export function generate_wallet_secrets(sign_message: Function): Promise<any>;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.7.10'
+export const version = '0.8.0'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @renegade-fi/node
 
+## 0.6.0
+
+### Minor Changes
+
+- add Base-specific withdrawal logic & client
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+
 ## 0.5.24
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.5.24",
+    "version": "0.6.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/src/clients/renegade/base.ts
+++ b/packages/node/src/clients/renegade/base.ts
@@ -216,6 +216,39 @@ export class RenegadeClient {
         });
     }
 
+    /**
+     * Base Sepolia client via seed.
+     *
+     * @param params.seed your 0x… seed
+     */
+    static newBaseSepoliaClient({ seed }: { seed: `0x${string}` }) {
+        return RenegadeClient.new({ chainId: CHAIN_IDS.BaseSepolia, seed });
+    }
+
+    /**
+     * Base Sepolia client with external keychain.
+     *
+     * @param params.walletSecrets  symmetric key + wallet ID
+     * @param params.signMessage    callback to sign auth messages
+     * @param params.publicKey      your public key
+     */
+    static newBaseSepoliaClientWithKeychain({
+        walletSecrets,
+        signMessage,
+        publicKey,
+    }: {
+        walletSecrets: GeneratedSecrets;
+        signMessage: (message: string) => Promise<`0x${string}`>;
+        publicKey: `0x${string}`;
+    }) {
+        return RenegadeClient.newWithExternalKeychain({
+            chainId: CHAIN_IDS.BaseSepolia,
+            walletSecrets,
+            signMessage,
+            publicKey,
+        });
+    }
+
     // -- Wallet Operations -- //
 
     async getWallet(

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+  - @renegade-fi/token@0.0.14
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+
 ## 0.6.10
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.10",
+    "version": "0.6.11",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+
 ## 0.4.22
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.22",
+    "version": "0.4.23",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/token-nextjs
 
+## 0.0.3
+
+### Patch Changes
+
+- @renegade-fi/token@0.0.14
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.8.0
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -67,22 +67,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
-dependencies = [
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more",
- "hex-literal",
- "itoa",
- "ruint",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-primitives"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
@@ -160,7 +144,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
 ]
@@ -753,7 +737,7 @@ name = "contracts-common"
 version = "0.1.0"
 source = "git+https://github.com/renegade-fi/renegade-contracts.git#4bbab0495ca9f1d431e2a2fddc639c9b12c7f78c"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
@@ -2791,7 +2775,8 @@ dependencies = [
 name = "renegade-utils"
 version = "0.0.2"
 dependencies = [
- "alloy-primitives 0.3.3",
+ "alloy-primitives",
+ "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -41,7 +41,8 @@ ruint = { version = "1.11.1", features = ["num-bigint"] }
 hmac = "0.12"
 
 # === Ethereum Utils === #
-alloy-primitives = { version = "0.3.1", default-features = false }
+alloy-primitives = { version = "0.7.7", default-features = false }
+alloy-sol-types = { version = "0.7.7", default-features = false }
 ethers = "2"
 
 # === Misc === #

--- a/wasm/src/common/keychain.rs
+++ b/wasm/src/common/keychain.rs
@@ -166,7 +166,7 @@ impl KeyChain {
         self.increment_nonce();
         let nonce = self.public_keys.nonce;
 
-        let sk_root = derive_sk_root_signing_key(&seed, Some(&nonce)).unwrap();
+        let sk_root = derive_sk_root_signing_key(seed, Some(&nonce)).unwrap();
         let rotated_keychain = derive_wallet_keychain(&sk_root).unwrap();
         self.set_pk_root(rotated_keychain.public_keys.pk_root);
         self.secret_keys.sk_root = rotated_keychain.secret_keys.sk_root;

--- a/wasm/src/common/types.rs
+++ b/wasm/src/common/types.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use super::{keychain::KeyChain, keyed_list::KeyedList};
 use crate::{
     circuit_types::{
@@ -147,5 +149,35 @@ impl Wallet {
         self.private_shares = new_private_share;
         self.blinded_public_shares = new_public_share;
         self.blinder = new_blinder;
+    }
+}
+
+/// The chain environment
+#[derive(Copy, Clone, Debug)]
+pub enum Chain {
+    /// The Arbitrum Sepolia chain
+    ArbitrumSepolia,
+    /// The Arbitrum One chain
+    ArbitrumOne,
+    /// The Base Sepolia chain
+    BaseSepolia,
+    /// The Base Mainnet chain
+    BaseMainnet,
+    /// Any local devnet chain
+    Devnet,
+}
+
+impl FromStr for Chain {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "arbitrum-sepolia" => Ok(Chain::ArbitrumSepolia),
+            "arbitrum-one" => Ok(Chain::ArbitrumOne),
+            "base-sepolia" => Ok(Chain::BaseSepolia),
+            "base-mainnet" => Ok(Chain::BaseMainnet),
+            "devnet" => Ok(Chain::Devnet),
+            _ => Err(format!("Invalid chain: {s}")),
+        }
     }
 }

--- a/wasm/src/errors.rs
+++ b/wasm/src/errors.rs
@@ -14,3 +14,10 @@ macro_rules! js_error {
         wasm_bindgen::JsError::new(&format!($($arg)*))
     };
 }
+
+#[macro_export]
+macro_rules! map_js_err {
+    () => {
+        |e| wasm_bindgen::JsError::new(&e.to_string())
+    };
+}

--- a/wasm/src/helpers.rs
+++ b/wasm/src/helpers.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::{Address, U160};
 use ark_ec::{twisted_edwards::Projective, CurveGroup};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use itertools::Itertools;
@@ -90,6 +91,15 @@ pub fn bytes_from_hex_string(hex: &str) -> Result<Vec<u8>, String> {
 /// A helper to serialize a BigUint to a hex string
 pub fn biguint_to_hex_string(val: &BigUint) -> String {
     format!("0x{}", val.to_str_radix(16 /* radix */))
+}
+
+/// Convert a `BigUint` to an `Address`
+pub fn biguint_to_address(biguint: &BigUint) -> Result<Address, String> {
+    let u160: U160 = biguint
+        .try_into()
+        .map_err(|_| "error converting BigUint to Address".to_string())?;
+
+    Ok(Address::from(u160))
 }
 
 /// A helper to deserialize a BigUint from a hex string

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -28,8 +28,10 @@ pub mod helpers;
 pub mod key_rotation;
 pub mod serde_def_types;
 pub mod signature;
+pub mod sol;
 pub mod types;
 pub mod utils;
+
 // -------------------------
 // | System-Wide Constants |
 // -------------------------

--- a/wasm/src/sol.rs
+++ b/wasm/src/sol.rs
@@ -1,0 +1,18 @@
+//! Relevant Solidity ABI definitions from the Renegade contracts
+
+use alloy_sol_types::sol;
+
+// Base-specific ABI definitions
+sol! {
+    enum TransferType {
+        Deposit,
+        Withdrawal,
+    }
+
+    struct ExternalTransfer {
+        address account;
+        address mint;
+        uint256 amount;
+        TransferType transferType;
+    }
+}


### PR DESCRIPTION
This PR implements the Base-specific signing pattern for authorizing withdrawals from the darkpool. This is necessary as the external transfer signature is expected to be over the ABI encoding of the Solidity contracts' `ExternalTransfer` struct, as opposed to the `postcard` serialization of the Stylus contracts' analogue.

### Testing
- [x] Test by initiating a withdrawal for a wallet allocated in the Base Sepolia darkpool