### PR TITLE
price-reporter: override binance price query

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+  - @renegade-fi/node@0.5.23
+
 ## 1.1.18
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.18",
+    "version": "1.1.19",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+  - @renegade-fi/node@0.5.23
+
 ## 0.1.18
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.18",
+    "version": "0.1.19",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.13
+
+### Patch Changes
+
+- @renegade-fi/node@0.5.23
+
 ## 0.0.12
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.12",
+    "version": "0.0.13",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.22
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+  - @renegade-fi/node@0.5.23
+
 ## 0.0.21
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.21",
+    "version": "0.0.22",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.7.9
+
+### Patch Changes
+
+- price-reporter: override binance price query
+
 ## 0.7.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.7.8",
+    "version": "0.7.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -83,7 +83,7 @@ export function getSDKConfig(chainId: number): SDKConfig {
 }
 
 /** Get the environment for a given chain ID */
-export function chainIdToEnvironment(chainId: number): Environment {
+export function chainIdToEnv(chainId: number): Environment {
     if (!isSupportedChainId(chainId)) {
         throw new Error(`Unsupported chain ID: ${chainId}`);
     }

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -3,10 +3,12 @@ import {
     AUTH_SERVER_URL_ARBITRUM_SEPOLIA,
     AUTH_SERVER_URL_BASE_SEPOLIA,
     CHAIN_IDS,
+    CHAIN_ID_TO_ENVIRONMENT,
     type ChainId,
     DARKPOOL_ADDRESS_ARBITRUM_ONE,
     DARKPOOL_ADDRESS_ARBITRUM_SEPOLIA,
     DARKPOOL_ADDRESS_BASE_SEPOLIA,
+    type Environment,
     HSE_URL_MAINNET,
     HSE_URL_TESTNET,
     PERMIT2_ADDRESS_ARBITRUM_ONE,
@@ -78,6 +80,14 @@ export function getSDKConfig(chainId: number): SDKConfig {
         throw new Error(`Unsupported chain ID: ${chainId}`);
     }
     return CONFIGS[chainId];
+}
+
+/** Get the environment for a given chain ID */
+export function chainIdToEnvironment(chainId: number): Environment {
+    if (!isSupportedChainId(chainId)) {
+        throw new Error(`Unsupported chain ID: ${chainId}`);
+    }
+    return CHAIN_ID_TO_ENVIRONMENT[chainId];
 }
 
 /** Quick HSE URL lookup */

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -336,5 +336,6 @@ export { parseBigJSON, stringifyForWasm } from "../utils/bigJSON.js";
 export {
     getSDKConfig,
     isSupportedChainId,
+    chainIdToEnv,
     type SDKConfig,
 } from "../chains/defaults.js";

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.7.8'
+export const version = '0.7.9'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.5.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+
 ## 0.5.22
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.5.22",
+    "version": "0.5.23",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @renegade-fi/price-reporter
 
+## 0.0.12
+
+### Patch Changes
+
+- price-reporter: override binance price query
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+  - @renegade-fi/token@0.0.12
+
 ## 0.0.11
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/price-reporter/src/client.ts
+++ b/packages/price-reporter/src/client.ts
@@ -95,10 +95,7 @@ export class PriceReporterClient {
             return errAsync(new PriceReporterError(ERR_INVALID_URL));
         }
 
-        const exchange = "binance";
-        const quote = getDefaultQuoteToken(exchange).address;
-
-        return client.getPriceByTopicResult(exchange, address, quote);
+        return client.getPriceResult(address);
     }
 
     // --- Private methods ---

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+
 ## 0.6.8
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.8",
+    "version": "0.6.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+
 ## 0.4.20
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.20",
+    "version": "0.4.21",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.7.9
+
 ## 0.0.11
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",


### PR DESCRIPTION
### Purpose
This PR modifies the deprecated `getBinancePrice` static method to use the `renegade` exchange price topic. In a future PR, we should migrate off of static methods that assume an environment variable is set.

This is safe because all callsites of `getBinancePrice` actually want the canonical exchange price.

### Testing
- [ ] Tested locally
- [ ] Test in testnet