### PR TITLE
packages: core, token-nextjs: add multi-chain remaps in NextJS context

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+  - @renegade-fi/node@0.6.2
+
 ## 1.1.22
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.22",
+    "version": "1.1.23",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+  - @renegade-fi/node@0.6.2
+
 ## 0.1.22
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.22",
+    "version": "0.1.23",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.17
+
+### Patch Changes
+
+- @renegade-fi/node@0.6.2
+- @renegade-fi/token@0.0.16
+
 ## 0.0.16
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.16",
+    "version": "0.0.17",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+  - @renegade-fi/node@0.6.2
+
 ## 0.0.25
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.25",
+    "version": "0.0.26",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.9.0
+
+### Minor Changes
+
+- multi-chain-aware NextJS token
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -9,6 +9,9 @@ import {
     DARKPOOL_ADDRESS_ARBITRUM_ONE,
     DARKPOOL_ADDRESS_ARBITRUM_SEPOLIA,
     DARKPOOL_ADDRESS_BASE_SEPOLIA,
+    ENVIRONMENT,
+    ENV_AGNOSTIC_CHAINS,
+    type EnvAgnosticChain,
     type Environment,
     HSE_URL_MAINNET,
     HSE_URL_TESTNET,
@@ -75,6 +78,11 @@ export function isSupportedChainId(chainId: number): chainId is ChainId {
     return chainId in CONFIGS;
 }
 
+/** Returns true if the environment is supported */
+export function isSupportedEnvironment(env: string): env is Environment {
+    return env in ENVIRONMENT;
+}
+
 /** Get full config or throw if unsupported */
 export function getSDKConfig(chainId: number): SDKConfig {
     if (!isSupportedChainId(chainId)) {
@@ -89,6 +97,38 @@ export function chainIdToEnv(chainId: number): Environment {
         throw new Error(`Unsupported chain ID: ${chainId}`);
     }
     return CHAIN_ID_TO_ENVIRONMENT[chainId];
+}
+
+/** Get the chain ID for a given environment and chain name */
+export function chainIdFromEnvAndName(env: Environment, name: EnvAgnosticChain): ChainId {
+    switch (env) {
+        case ENVIRONMENT.Mainnet:
+            switch (name) {
+                case ENV_AGNOSTIC_CHAINS.Arbitrum:
+                    return CHAIN_IDS.ArbitrumOne;
+                default:
+                    throw new Error(`Unsupported env / chain: ${env} / ${name}`);
+            }
+
+        case ENVIRONMENT.Testnet:
+            switch (name) {
+                case ENV_AGNOSTIC_CHAINS.Arbitrum:
+                    return CHAIN_IDS.ArbitrumSepolia;
+                case ENV_AGNOSTIC_CHAINS.Base:
+                    return CHAIN_IDS.BaseSepolia;
+            }
+    }
+}
+
+/** Get the env agnostic chain for a given chain ID */
+export function getEnvAgnosticChain(chainId: ChainId): EnvAgnosticChain {
+    switch (chainId) {
+        case CHAIN_IDS.ArbitrumOne:
+        case CHAIN_IDS.ArbitrumSepolia:
+            return ENV_AGNOSTIC_CHAINS.Arbitrum;
+        case CHAIN_IDS.BaseSepolia:
+            return ENV_AGNOSTIC_CHAINS.Base;
+    }
 }
 
 /** Quick HSE URL lookup */

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -42,6 +42,12 @@ export const CHAIN_ID_TO_ENVIRONMENT: Record<ChainId, Environment> = {
     [CHAIN_IDS.BaseSepolia]: "testnet",
 };
 
+export const ENV_AGNOSTIC_CHAINS = {
+    Arbitrum: "arbitrum",
+    Base: "base",
+} as const;
+export type EnvAgnosticChain = (typeof ENV_AGNOSTIC_CHAINS)[keyof typeof ENV_AGNOSTIC_CHAINS];
+
 ////////////////////////////////////////////////////////////////////////////////
 // Environment-Specific Constants
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -336,6 +336,9 @@ export { parseBigJSON, stringifyForWasm } from "../utils/bigJSON.js";
 export {
     getSDKConfig,
     isSupportedChainId,
+    isSupportedEnvironment,
     chainIdToEnv,
+    chainIdFromEnvAndName,
+    getEnvAgnosticChain,
     type SDKConfig,
 } from "../chains/defaults.js";

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.8.1'
+export const version = '0.9.0'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+  - @renegade-fi/token@0.0.16
+
 ## 0.0.15
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+
 ## 0.6.12
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.12",
+    "version": "0.6.13",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+
 ## 0.4.24
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.24",
+    "version": "0.4.25",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.0
+
+### Minor Changes
+
+- multi-chain-aware NextJS token
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+  - @renegade-fi/token@0.0.16
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",
@@ -30,6 +30,7 @@
     "keywords": [],
     "author": "",
     "dependencies": {
+        "@renegade-fi/core": "workspace:^",
         "@renegade-fi/token": "workspace:^"
     }
 }

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.0
+
 ## 0.0.15
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
 
   packages/token-nextjs:
     dependencies:
+      '@renegade-fi/core':
+        specifier: workspace:^
+        version: link:../core
       '@renegade-fi/token':
         specifier: workspace:^
         version: link:../token


### PR DESCRIPTION
This PR updates the `token-nextjs` package to be multi-chain capable. Concretely, this means it now adds a remap for each of the potential environment variables (`NEXT_PUBLIC_${chain}_TOKEN_MAPPING`). This required adding an enum for env-agnostic chain names, and also having the module expect a `NEXT_PUBLIC_CHAIN_ENVIRONMENT` env var to be set, which is one of the `Environment` values (`testnet`, `mainnet`).