### PR TITLE
packages: core: add base mainnet config

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.24
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.1
+  - @renegade-fi/node@0.6.3
+
 ## 1.1.23
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.23",
+    "version": "1.1.24",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.24
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.1
+  - @renegade-fi/node@0.6.3
+
 ## 0.1.23
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.23",
+    "version": "0.1.24",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/token@0.0.17
+  - @renegade-fi/node@0.6.3
+
 ## 0.0.17
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.17",
+    "version": "0.0.18",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.1
+  - @renegade-fi/node@0.6.3
+
 ## 0.0.26
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.26",
+    "version": "0.0.27",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.9.1
+
+### Patch Changes
+
+- add base mainnet config
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -1,6 +1,7 @@
 import {
     AUTH_SERVER_URL_ARBITRUM_ONE,
     AUTH_SERVER_URL_ARBITRUM_SEPOLIA,
+    AUTH_SERVER_URL_BASE_MAINNET,
     AUTH_SERVER_URL_BASE_SEPOLIA,
     CHAIN_IDS,
     CHAIN_ID_TO_ENVIRONMENT,
@@ -8,6 +9,7 @@ import {
     type ChainId,
     DARKPOOL_ADDRESS_ARBITRUM_ONE,
     DARKPOOL_ADDRESS_ARBITRUM_SEPOLIA,
+    DARKPOOL_ADDRESS_BASE_MAINNET,
     DARKPOOL_ADDRESS_BASE_SEPOLIA,
     ENVIRONMENT,
     ENV_AGNOSTIC_CHAINS,
@@ -17,11 +19,13 @@ import {
     HSE_URL_TESTNET,
     PERMIT2_ADDRESS_ARBITRUM_ONE,
     PERMIT2_ADDRESS_ARBITRUM_SEPOLIA,
+    PERMIT2_ADDRESS_BASE_MAINNET,
     PERMIT2_ADDRESS_BASE_SEPOLIA,
     PRICE_REPORTER_URL_MAINNET,
     PRICE_REPORTER_URL_TESTNET,
     RELAYER_URL_ARBITRUM_ONE,
     RELAYER_URL_ARBITRUM_SEPOLIA,
+    RELAYER_URL_BASE_MAINNET,
     RELAYER_URL_BASE_SEPOLIA,
 } from "../constants.js";
 
@@ -59,6 +63,17 @@ export const CONFIGS: Record<ChainId, SDKConfig> = {
         priceReporterUrl: PRICE_REPORTER_URL_TESTNET,
         permit2Address: PERMIT2_ADDRESS_ARBITRUM_SEPOLIA,
         authServerUrl: AUTH_SERVER_URL_ARBITRUM_SEPOLIA,
+    },
+    [CHAIN_IDS.BaseMainnet]: {
+        id: CHAIN_IDS.BaseMainnet,
+        chainSpecifier: CHAIN_SPECIFIERS[CHAIN_IDS.BaseMainnet],
+        hseBaseUrl: HSE_URL_MAINNET,
+        darkpoolAddress: DARKPOOL_ADDRESS_BASE_MAINNET,
+        relayerUrl: RELAYER_URL_BASE_MAINNET,
+        websocketUrl: `wss://${RELAYER_URL_BASE_MAINNET}:4000`,
+        priceReporterUrl: PRICE_REPORTER_URL_MAINNET,
+        permit2Address: PERMIT2_ADDRESS_BASE_MAINNET,
+        authServerUrl: AUTH_SERVER_URL_BASE_MAINNET,
     },
     [CHAIN_IDS.BaseSepolia]: {
         id: CHAIN_IDS.BaseSepolia,
@@ -127,6 +142,7 @@ export function getEnvAgnosticChain(chainId: ChainId): EnvAgnosticChain {
         case CHAIN_IDS.ArbitrumSepolia:
             return ENV_AGNOSTIC_CHAINS.Arbitrum;
         case CHAIN_IDS.BaseSepolia:
+        case CHAIN_IDS.BaseMainnet:
             return ENV_AGNOSTIC_CHAINS.Base;
     }
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -19,6 +19,7 @@ export const CHAIN_IDS = {
     ArbitrumOne: 42161,
     ArbitrumSepolia: 421614,
     BaseSepolia: 84532,
+    BaseMainnet: 8453,
 } as const;
 
 export type ChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
@@ -26,6 +27,7 @@ export type ChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
 export const CHAIN_SPECIFIERS = {
     [CHAIN_IDS.ArbitrumOne]: "arbitrum-one",
     [CHAIN_IDS.ArbitrumSepolia]: "arbitrum-sepolia",
+    [CHAIN_IDS.BaseMainnet]: "base-mainnet",
     [CHAIN_IDS.BaseSepolia]: "base-sepolia",
 } as const;
 export type ChainSpecifier = (typeof CHAIN_SPECIFIERS)[keyof typeof CHAIN_SPECIFIERS];
@@ -39,6 +41,7 @@ export type Environment = (typeof ENVIRONMENT)[keyof typeof ENVIRONMENT];
 export const CHAIN_ID_TO_ENVIRONMENT: Record<ChainId, Environment> = {
     [CHAIN_IDS.ArbitrumOne]: "mainnet",
     [CHAIN_IDS.ArbitrumSepolia]: "testnet",
+    [CHAIN_IDS.BaseMainnet]: "mainnet",
     [CHAIN_IDS.BaseSepolia]: "testnet",
 };
 
@@ -64,11 +67,13 @@ export const HSE_URL_TESTNET = "https://testnet.historical-state.renegade.fi:300
 
 export const RELAYER_URL_ARBITRUM_ONE = "arbitrum-one.relayer.renegade.fi";
 export const RELAYER_URL_ARBITRUM_SEPOLIA = "arbitrum-sepolia.relayer.renegade.fi";
+export const RELAYER_URL_BASE_MAINNET = "base-mainnet.relayer.renegade.fi";
 export const RELAYER_URL_BASE_SEPOLIA = "base-sepolia.relayer.renegade.fi";
 
 export const AUTH_SERVER_URL_ARBITRUM_ONE = "https://arbitrum-one.auth-server.renegade.fi:3000";
 export const AUTH_SERVER_URL_ARBITRUM_SEPOLIA =
     "https://arbitrum-sepolia.auth-server.renegade.fi:3000";
+export const AUTH_SERVER_URL_BASE_MAINNET = "https://base-mainnet.auth-server.renegade.fi:3000";
 export const AUTH_SERVER_URL_BASE_SEPOLIA = "https://base-sepolia.auth-server.renegade.fi:3000";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,10 +82,12 @@ export const AUTH_SERVER_URL_BASE_SEPOLIA = "https://base-sepolia.auth-server.re
 
 export const DARKPOOL_ADDRESS_ARBITRUM_ONE = "0x30bD8eAb29181F790D7e495786d4B96d7AfDC518";
 export const DARKPOOL_ADDRESS_ARBITRUM_SEPOLIA = "0x9af58f1ff20ab22e819e40b57ffd784d115a9ef5";
+export const DARKPOOL_ADDRESS_BASE_MAINNET = "0xb4a96068577141749CC8859f586fE29016C935dB";
 export const DARKPOOL_ADDRESS_BASE_SEPOLIA = "0x653C95391644EEE16E4975a7ef1f46e0B8276695";
 
 export const PERMIT2_ADDRESS_ARBITRUM_ONE = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 export const PERMIT2_ADDRESS_ARBITRUM_SEPOLIA = "0x9458198bcc289c42e460cb8ca143e5854f734442";
+export const PERMIT2_ADDRESS_BASE_MAINNET = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 export const PERMIT2_ADDRESS_BASE_SEPOLIA = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -22,22 +22,7 @@ export function b64_to_hex_hmac_key(b64_key: string): string;
 * @param {string} symmetric_key
 * @returns {Promise<any>}
 */
-export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
 export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {Function} sign_message
-* @returns {Promise<any>}
-*/
-export function generate_wallet_secrets(sign_message: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {bigint} nonce
@@ -196,3 +181,18 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 * @returns {any}
 */
 export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, sponsored_quote_response: string, receiver_address: string): any;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {Function} sign_message
+* @returns {Promise<any>}
+*/
+export function generate_wallet_secrets(sign_message: Function): Promise<any>;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.0'
+export const version = '0.9.1'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.6.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.1
+
 ## 0.6.2
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/token@0.0.17
+  - @renegade-fi/core@0.9.1
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.1
+
 ## 0.6.14
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.14",
+    "version": "0.6.15",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.1
+
 ## 0.4.25
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.25",
+    "version": "0.4.26",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/token@0.0.17
+  - @renegade-fi/core@0.9.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/token
 
+## 0.0.17
+
+### Patch Changes
+
+- add base mainnet config
+- Updated dependencies
+  - @renegade-fi/core@0.9.1
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",

--- a/packages/token/src/index.ts
+++ b/packages/token/src/index.ts
@@ -41,7 +41,7 @@ let DEFAULT_CHAIN: ChainId | "default" | undefined = undefined;
 
 /** The token class */
 export class Token {
-    private static tokenMappings: Partial<Record<ChainId | "default", TokenMapping>>;
+    private static tokenMappings: Partial<Record<ChainId | "default", TokenMapping>> = {};
 
     /** Fetch a remap from the repo */
     static async fetchRemapFromRepo(chain: number) {


### PR DESCRIPTION
This PR adds config entries for the Base mainnet deployment.

Testing of all the actions on Base mainnet can be deferred, this is worth releasing so that consumers of the SDK can access these config entries in order to integrate properly.