### PR TITLE
packages: core, token-nextjs: fix improper env var usage

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+  - @renegade-fi/node@0.6.4
+
 ## 1.1.24
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.24",
+    "version": "1.1.25",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+  - @renegade-fi/node@0.6.4
+
 ## 0.1.24
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.24",
+    "version": "0.1.25",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.19
+
+### Patch Changes
+
+- @renegade-fi/node@0.6.4
+- @renegade-fi/token@0.0.18
+
 ## 0.0.18
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.18",
+    "version": "0.0.19",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.28
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+  - @renegade-fi/node@0.6.4
+
 ## 0.0.27
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.27",
+    "version": "0.0.28",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.9.2
+
+### Patch Changes
+
+- proper env var access in token-nextjs
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -95,7 +95,7 @@ export function isSupportedChainId(chainId: number): chainId is ChainId {
 
 /** Returns true if the environment is supported */
 export function isSupportedEnvironment(env: string): env is Environment {
-    return env in ENVIRONMENT;
+    return Object.values(ENVIRONMENT).includes(env as Environment);
 }
 
 /** Get full config or throw if unsupported */

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.1'
+export const version = '0.9.2'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.6.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+
 ## 0.6.3
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+  - @renegade-fi/token@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+
 ## 0.6.15
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.15",
+    "version": "0.6.16",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+
 ## 0.4.26
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.26",
+    "version": "0.4.27",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.2
+
+### Patch Changes
+
+- proper env var access in token-nextjs
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+  - @renegade-fi/token@0.0.18
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token-nextjs/src/index.ts
+++ b/packages/token-nextjs/src/index.ts
@@ -28,8 +28,19 @@ const PACKAGE_NAME = "@renegade-fi/token-nextjs";
     const envAgnosticChains = Object.values(ENV_AGNOSTIC_CHAINS);
 
     for (const chain of envAgnosticChains) {
-        const envVarName = `NEXT_PUBLIC_${chain.toUpperCase()}_TOKEN_MAPPING`;
-        const tokenMappingJson = process.env[envVarName];
+        let tokenMappingJson: string | undefined;
+        let envVarName: string | undefined;
+
+        switch (chain) {
+            case ENV_AGNOSTIC_CHAINS.Arbitrum:
+                tokenMappingJson = process.env.NEXT_PUBLIC_ARBITRUM_TOKEN_MAPPING;
+                envVarName = "NEXT_PUBLIC_ARBITRUM_TOKEN_MAPPING";
+                break;
+            case ENV_AGNOSTIC_CHAINS.Base:
+                tokenMappingJson = process.env.NEXT_PUBLIC_BASE_TOKEN_MAPPING;
+                envVarName = "NEXT_PUBLIC_BASE_TOKEN_MAPPING";
+                break;
+        }
 
         if (
             !(
@@ -52,9 +63,9 @@ const PACKAGE_NAME = "@renegade-fi/token-nextjs";
             CoreTokenAliased.addRemapFromString(chainId, tokenMappingJson);
 
             // Check if any tokens were actually loaded after parsing
-            if (CoreTokenAliased.getAllTokens().length > 0) {
+            if (CoreTokenAliased.getAllTokensOnChain(chainId).length > 0) {
                 console.info(
-                    `${logPrefix} Token mapping initialized successfully from ${envVarName}. Loaded ${CoreTokenAliased.getAllTokens().length} tokens.`,
+                    `${logPrefix} Token mapping initialized successfully from ${envVarName}. Loaded ${CoreTokenAliased.getAllTokensOnChain(chainId).length} tokens.`,
                 );
             } else {
                 console.warn(

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.2
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",


### PR DESCRIPTION
This PR gets the `token-nextjs` package into a usable state by ensuring that it properly utilizes the designated environment variables. We can't index into `process.env` client-side because NextJS will find-and-replace all `process.env.NEXT_PUBLIC_*` occurrences w/ the given variables, so we make sure to use this access pattern.

### Testing
- [x] Tested client & server-side locally w/ NextJs project