### PR TITLE
packages: price-reporter: expose chain-specific token price getters

### DIFF
--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/token@0.0.19
+
 ## 0.0.19
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.19",
+    "version": "0.0.20",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.19
+
+### Patch Changes
+
+- use renegade price topic
+- Updated dependencies
+  - @renegade-fi/token@0.0.19
+
 ## 0.0.18
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/price-reporter/src/constants.ts
+++ b/packages/price-reporter/src/constants.ts
@@ -23,3 +23,15 @@ export const PRICE_REPORTER_ROUTE = (exchange: string, base: string, quote: stri
  * The alias for the canonical exchange
  */
 export const RENEGADE_EXCHANGE = "renegade";
+
+/**
+ * @param base - The base token to fetch the price for
+ * @returns The topic name for the Renegade price of a given token
+ */
+const RENEGADE_PRICE_TOPIC = (base: string) => `${RENEGADE_EXCHANGE}-${base.toLowerCase()}`;
+
+/**
+ * @param base - The base token to fetch the price for
+ * @returns The HTTP GET route to fetch the price from the price reporter
+ */
+export const RENEGADE_PRICE_ROUTE = (base: string) => `/price/${RENEGADE_PRICE_TOPIC(base)}`;

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/token@0.0.19
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/token
 
+## 0.0.19
+
+### Patch Changes
+
+- use renegade price topic
+
 ## 0.0.18
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",

--- a/packages/token/src/index.ts
+++ b/packages/token/src/index.ts
@@ -329,7 +329,7 @@ const DEFAULT_TOKEN = Token.create(
     Token.resolveDefaultChainId(),
 );
 
-/** @deprecated Use `Token.fromTickerOnChain` instead */
+/** @deprecated Use `Token.getDefaultQuoteTokenOnChain` instead */
 export function getDefaultQuoteToken(exchange: Exchange): Token {
     switch (exchange) {
         case "binance":


### PR DESCRIPTION
This PR adds two new methods to the `PriceReporterClient`, which fetch the price for a `Token`, expecting its `chain` to be set. This allows us to construct the correct quote token address for the price topic that we request from the price reporter.

### Testing
- [ ] Test by fetching prices in a multi-chain context