### PR TITLE
core: chains: add Base case for chainIdFromEnvAndName

### DIFF
--- a/examples/external-match/CHANGELOG.md
+++ b/examples/external-match/CHANGELOG.md
@@ -1,5 +1,13 @@
 # renegade-external-match-example
 
+## 1.1.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+  - @renegade-fi/node@0.6.5
+
 ## 1.1.25
 
 ### Patch Changes

--- a/examples/external-match/package.json
+++ b/examples/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/external-match-example",
-    "version": "1.1.25",
+    "version": "1.1.26",
     "description": "Example of fetching and assembling external matches using Renegade SDK",
     "type": "module",
     "scripts": {

--- a/examples/in-kind-gas-sponsorship/CHANGELOG.md
+++ b/examples/in-kind-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/in-kind-gas-sponsorship-example
 
+## 0.1.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+  - @renegade-fi/node@0.6.5
+
 ## 0.1.25
 
 ### Patch Changes

--- a/examples/in-kind-gas-sponsorship/package.json
+++ b/examples/in-kind-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/in-kind-gas-sponsorship-example",
     "private": true,
-    "version": "0.1.25",
+    "version": "0.1.26",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/malleable-external-match/CHANGELOG.md
+++ b/examples/malleable-external-match/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/malleable-external-match-example
 
+## 0.0.21
+
+### Patch Changes
+
+- @renegade-fi/node@0.6.5
+- @renegade-fi/token@0.0.20
+
 ## 0.0.20
 
 ### Patch Changes

--- a/examples/malleable-external-match/package.json
+++ b/examples/malleable-external-match/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/malleable-external-match-example",
     "private": true,
-    "version": "0.0.20",
+    "version": "0.0.21",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/examples/native-eth-gas-sponsorship/CHANGELOG.md
+++ b/examples/native-eth-gas-sponsorship/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/gas-sponsorship-example
 
+## 0.0.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+  - @renegade-fi/node@0.6.5
+
 ## 0.0.28
 
 ### Patch Changes

--- a/examples/native-eth-gas-sponsorship/package.json
+++ b/examples/native-eth-gas-sponsorship/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/native-eth-gas-sponsorship-example",
     "private": true,
-    "version": "0.0.28",
+    "version": "0.0.29",
     "type": "module",
     "scripts": {
         "start": "tsx --require dotenv/config index.ts"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.9.3
+
+### Patch Changes
+
+- fix chainIdFromEnvAndName
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/chains/defaults.ts
+++ b/packages/core/src/chains/defaults.ts
@@ -121,6 +121,8 @@ export function chainIdFromEnvAndName(env: Environment, name: EnvAgnosticChain):
             switch (name) {
                 case ENV_AGNOSTIC_CHAINS.Arbitrum:
                     return CHAIN_IDS.ArbitrumOne;
+                case ENV_AGNOSTIC_CHAINS.Base:
+                    return CHAIN_IDS.BaseMainnet;
                 default:
                     throw new Error(`Unsupported env / chain: ${env} / ${name}`);
             }
@@ -131,6 +133,8 @@ export function chainIdFromEnvAndName(env: Environment, name: EnvAgnosticChain):
                     return CHAIN_IDS.ArbitrumSepolia;
                 case ENV_AGNOSTIC_CHAINS.Base:
                     return CHAIN_IDS.BaseSepolia;
+                default:
+                    throw new Error(`Unsupported env / chain: ${env} / ${name}`);
             }
     }
 }

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.2'
+export const version = '0.9.3'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.6.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+
 ## 0.6.4
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+  - @renegade-fi/token@0.0.20
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+
 ## 0.6.16
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.16",
+    "version": "0.6.17",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.28
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+
 ## 0.4.27
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.27",
+    "version": "0.4.28",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+  - @renegade-fi/token@0.0.20
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.3
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",


### PR DESCRIPTION
This PR adds an `ENV_AGNOSTIC_CHAINS.Base` case to the `ENVIRONMENT.Mainnet` branch of the `chainIdFromEnvAndName` helper.