### PR TITLE
core: add chain id to config state

### DIFF
--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -60,6 +60,7 @@ export function createConfig(parameters: CreateConfigParameters): InternalConfig
     function getInitialState(): State {
         return {
             seed: undefined,
+            chainId: undefined,
             status: "disconnected",
             id: undefined,
         };
@@ -76,6 +77,7 @@ export function createConfig(parameters: CreateConfigParameters): InternalConfig
                           return {
                               id: state.id,
                               seed: state.seed,
+                              chainId: state.chainId,
                               status: state.status,
                           } satisfies PartializedState;
                       },
@@ -221,6 +223,7 @@ export type RenegadeConfig = InternalConfig | ExternalConfig;
 
 export interface State {
     seed?: Hex | undefined;
+    chainId?: number;
     status?: "in relayer" | "disconnected" | "looking up" | "creating wallet" | "connecting";
     id?: string | undefined;
 }
@@ -232,4 +235,6 @@ export const keyTypes = {
     NONE: "none",
 } as const;
 
-export type PartializedState = Evaluate<ExactPartial<Pick<State, "id" | "seed" | "status">>>;
+export type PartializedState = Evaluate<
+    ExactPartial<Pick<State, "id" | "seed" | "chainId" | "status">>
+>;

--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -15,7 +15,6 @@ export type HydrateProps = {
 export function Hydrate(parameters: React.PropsWithChildren<HydrateProps>) {
     const { children, config, initialState, reconnectOnMount = true } = parameters;
     const [isInitialized, setIsInitialized] = useState(false);
-    console.log("Config exists:", !!config);
 
     const { onMount } = hydrate(config, {
         initialState,


### PR DESCRIPTION
### Purpose
This PR adds the chain ID field to the internal state of the config object. This is necessary to provide a stable reference to the chain used to sign in, as the client may switch chains (for example during the bridge and deposit flow).

### Testing
- [ ] Tested locally
- [ ] Test in testnet