### PR TITLE
packages: token-nextjs: set sideEffects=true

### DIFF
--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.5
+
+### Patch Changes
+
+- set sideEffects:true in token-nextjs
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",
@@ -9,7 +9,7 @@
         "!src/**/*.test.ts",
         "!src/**/*.test-d.ts"
     ],
-    "sideEffects": false,
+    "sideEffects": true,
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
This PR sets `sideEffects: true` for the `token-nextjs` package, so that bundlers know not to tree-shake it if it is imported but unused.