### PR TITLE
core: actions: assembleExternalQuote: Add `allowShared` parameter

### DIFF
--- a/packages/core/src/actions/assembleExternalQuote.ts
+++ b/packages/core/src/actions/assembleExternalQuote.ts
@@ -17,6 +17,7 @@ export type AssembleExternalQuoteParameters = {
     receiverAddress?: `0x${string}`;
     requestGasSponsorship?: boolean;
     refundAddress?: `0x${string}`;
+    allowShared?: boolean;
 };
 
 export type AssembleExternalQuoteReturnType = SponsoredMatchResponse;
@@ -34,6 +35,7 @@ export async function assembleExternalQuote(
         receiverAddress = "",
         requestGasSponsorship,
         refundAddress,
+        allowShared = false,
     } = parameters;
 
     if (requestGasSponsorship !== undefined || refundAddress !== undefined) {
@@ -51,6 +53,7 @@ export async function assembleExternalQuote(
     const stringifiedOrder = updatedOrder ? stringifyForWasm(updatedOrder) : "";
     const body = config.utils.assemble_external_match(
         doGasEstimation,
+        allowShared,
         stringifiedOrder,
         stringifiedQuote,
         receiverAddress,

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -22,22 +22,7 @@ export function b64_to_hex_hmac_key(b64_key: string): string;
 * @param {string} symmetric_key
 * @returns {Promise<any>}
 */
-export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
 export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
-* @param {Function} sign_message
-* @returns {Promise<any>}
-*/
-export function generate_wallet_secrets(sign_message: Function): Promise<any>;
 /**
 * @param {string} seed
 * @param {bigint} nonce
@@ -190,9 +175,25 @@ export function new_external_order(base_mint: string, quote_mint: string, side: 
 export function new_external_quote_request(base_mint: string, quote_mint: string, side: string, base_amount: string, quote_amount: string, min_fill_size: string): any;
 /**
 * @param {boolean} do_gas_estimation
+* @param {boolean} allow_shared
 * @param {string} updated_order
 * @param {string} sponsored_quote_response
 * @param {string} receiver_address
 * @returns {any}
 */
-export function assemble_external_match(do_gas_estimation: boolean, updated_order: string, sponsored_quote_response: string, receiver_address: string): any;
+export function assemble_external_match(do_gas_estimation: boolean, allow_shared: boolean, updated_order: string, sponsored_quote_response: string, receiver_address: string): any;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {Function} sign_message
+* @returns {Promise<any>}
+*/
+export function generate_wallet_secrets(sign_message: Function): Promise<any>;

--- a/wasm/src/external_api/http.rs
+++ b/wasm/src/external_api/http.rs
@@ -749,11 +749,17 @@ pub fn new_external_quote_request(
 /// The request type for assembling an external match, potentially with gas sponsorship
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AssembleExternalMatchRequest {
-    /// The signed external match quote
-    pub signed_quote: SignedExternalQuote,
     /// Whether or not to include gas estimation in the response
     #[serde(default)]
     pub do_gas_estimation: bool,
+    /// Whether or not to allow shared access to the resulting bundle
+    ///
+    /// If true, the bundle may be sent to other clients requesting an external
+    /// match. If false, the bundle will be exclusively held for some time
+    #[serde(default)]
+    pub allow_shared: bool,
+    /// The signed external match quote
+    pub signed_quote: SignedExternalQuote,
     /// The receiver address of the match, if not the message sender
     #[serde(default)]
     pub receiver_address: Option<String>,
@@ -765,6 +771,7 @@ pub struct AssembleExternalMatchRequest {
 #[wasm_bindgen]
 pub fn assemble_external_match(
     do_gas_estimation: bool,
+    allow_shared: bool,
     updated_order: &str,
     sponsored_quote_response: &str,
     receiver_address: &str,
@@ -790,9 +797,10 @@ pub fn assemble_external_match(
 
     let req = AssembleExternalMatchRequest {
         do_gas_estimation,
+        allow_shared,
         receiver_address,
         updated_order,
-        signed_quote,
+        signed_quote: signed_quote,
     };
 
     Ok(JsValue::from_str(&serde_json::to_string(&req).unwrap()))


### PR DESCRIPTION
### Purpose
This PR adds the `allowShared` param to the assemble external match request.

### Testing
- [x] Tested locally with a modified example