### PR TITLE
react: ensure ws topic subscription happens after indexing

### DIFF
--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -8,6 +8,8 @@ import {
 
 import * as RustUtils from "../../renegade-utils/index.js";
 
+export { default as RustUtils } from "../../renegade-utils/index.js";
+
 function createConfig(
     ...args: Parameters<typeof core_createConfig>
 ): ReturnType<typeof core_createConfig> {
@@ -206,6 +208,8 @@ export { useWasmInitialized } from "../wasm.js";
 ////////////////////////////////////////////////////////////////////////////////
 
 export { useQuery } from "../utils/query.js";
+
+export { createSignedWebSocketRequest } from "../utils/websocket.js";
 
 ////////////////////////////////////////////////////////////////////////////////
 // @renegade/core

--- a/packages/react/src/hooks/useIsIndexed.ts
+++ b/packages/react/src/hooks/useIsIndexed.ts
@@ -1,0 +1,32 @@
+import { getWalletFromRelayer } from "@renegade-fi/core";
+import { useQuery } from "@tanstack/react-query";
+import { useWasmInitialized } from "../wasm.js";
+import { useConfig } from "./useConfig.js";
+import { useWalletId } from "./useWalletId.js";
+
+/**
+ * Checks if the wallet is indexed in the relayer.
+ * This is necessary to subscribe to topics once a wallet is indexed.
+ * The query runs every 2 seconds until the wallet is indexed, or 30 times (1 minute) if the wallet is not indexed.
+ * This is fine because in most cases the wallet is indexed in >> 1 minute.
+ * If after 1 minute the wallet is not indexed, there is a higher level issue that should be addressed.
+ */
+export function useIsIndexed() {
+    const config = useConfig();
+    const walletId = useWalletId();
+    const isWasmInitialized = useWasmInitialized();
+
+    return useQuery<boolean>({
+        queryKey: ["wallet", "is-indexed", walletId],
+        queryFn: async () => {
+            if (!walletId || !isWasmInitialized || !config) throw new Error("Invalid state");
+            return getWalletFromRelayer(config).then((wallet) => !!wallet.id);
+        },
+        refetchInterval: (query) => {
+            return query.state.data === true ? false : 2000;
+        },
+        staleTime: Number.POSITIVE_INFINITY,
+        enabled: !!walletId && !!isWasmInitialized && !!config,
+        retry: 30
+    });
+}

--- a/packages/react/src/hooks/useIsIndexed.ts
+++ b/packages/react/src/hooks/useIsIndexed.ts
@@ -8,7 +8,7 @@ import { useWalletId } from "./useWalletId.js";
  * Checks if the wallet is indexed in the relayer.
  * This is necessary to subscribe to topics once a wallet is indexed.
  * The query runs every 2 seconds until the wallet is indexed, or 30 times (1 minute) if the wallet is not indexed.
- * This is fine because in most cases the wallet is indexed in >> 1 minute.
+ * This is fine because in most cases the wallet is indexed in << 1 minute.
  * If after 1 minute the wallet is not indexed, there is a higher level issue that should be addressed.
  */
 export function useIsIndexed() {

--- a/packages/react/src/hooks/useTaskHistoryWebSocket.ts
+++ b/packages/react/src/hooks/useTaskHistoryWebSocket.ts
@@ -13,7 +13,7 @@ import { useWebSocket } from "react-use-websocket/dist/lib/use-websocket.js";
 import { createSignedWebSocketRequest } from "../utils/websocket.js";
 import { useWasmInitialized } from "../wasm.js";
 import { useConfig } from "./useConfig.js";
-import { useStatus } from "./useStatus.js";
+import { useIsIndexed } from "./useIsIndexed.js";
 import { useWalletId } from "./useWalletId.js";
 
 export type UseTaskHistoryWebSocketParameters = {
@@ -25,7 +25,6 @@ export type UseTaskHistoryWebSocketParameters = {
 export function useTaskHistoryWebSocket(parameters: UseTaskHistoryWebSocketParameters = {}) {
     const isWasmInitialized = useWasmInitialized();
     const config = useConfig(parameters);
-    const status = useStatus(parameters);
     const walletId = useWalletId();
 
     const { enabled = true, onUpdate } = parameters;
@@ -47,10 +46,12 @@ export function useTaskHistoryWebSocket(parameters: UseTaskHistoryWebSocketParam
                 } catch (_) {}
             },
             share: true,
-            shouldReconnect: () => Boolean(enabled && walletId && status === "in relayer"),
+            shouldReconnect: () => Boolean(enabled && walletId),
         },
         enabled && !!config?.getWebsocketBaseUrl(),
     );
+
+    const { data: isIndexed } = useIsIndexed();
 
     useEffect(() => {
         // Capture the current (old) wallet id in a local variable
@@ -60,10 +61,10 @@ export function useTaskHistoryWebSocket(parameters: UseTaskHistoryWebSocketParam
             !enabled ||
             !currentWalletId ||
             readyState !== ReadyState.OPEN ||
-            status !== "in relayer" ||
             !isWasmInitialized ||
             !config ||
-            !config.state.seed
+            !config.state.seed ||
+            !isIndexed
         )
             return;
 
@@ -76,5 +77,5 @@ export function useTaskHistoryWebSocket(parameters: UseTaskHistoryWebSocketParam
         const subscriptionMessage = createSignedWebSocketRequest(config, symmetricKey, body);
 
         sendJsonMessage(subscriptionMessage);
-    }, [enabled, walletId, readyState, status, isWasmInitialized, sendJsonMessage, config]);
+    }, [enabled, walletId, readyState, isWasmInitialized, sendJsonMessage, config, isIndexed]);
 }

--- a/packages/react/src/hooks/useWalletId.ts
+++ b/packages/react/src/hooks/useWalletId.ts
@@ -3,7 +3,6 @@
 import type { Config } from "@renegade-fi/core";
 import { useEffect, useState } from "react";
 import { useConfig } from "./useConfig.js";
-import { useStatus } from "./useStatus.js";
 
 export type UseWalletIdParameters = {
     config?: Config;
@@ -13,11 +12,10 @@ export type UseWalletIdReturnType = string | undefined;
 
 export function useWalletId(parameters: UseWalletIdParameters = {}): UseWalletIdReturnType {
     const config = useConfig(parameters);
-    const status = useStatus(parameters);
     const [walletId, setWalletId] = useState<string | undefined>(config?.state.id);
 
     useEffect(() => {
-        if (!config || status !== "in relayer") return;
+        if (!config) return;
         setWalletId(config.state.id);
         const unsubscribe = config.subscribe(
             (state) => state.id,
@@ -26,7 +24,7 @@ export function useWalletId(parameters: UseWalletIdParameters = {}): UseWalletId
         return () => {
             unsubscribe();
         };
-    }, [status, config]);
+    }, [config]);
 
     return walletId;
 }


### PR DESCRIPTION
### Purpose
This PR ensures websocket topics are subscribed to only after the wallet has been indexed in the relayer. Previously, this was handled by the status field in the config. We have since decoupled the indexed state of a wallet from the relayer so we must check for this per websocket hook.

### Testing
- [x] Tested locally
- [ ] Test in testnet