### PR TITLE
wasm, actions: computeWalletNullifier action

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.9.8
+
+### Patch Changes
+
+- add getWalletNullifier action
+
 ## 0.9.7
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.9.7",
+    "version": "0.9.8",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/actions/getWalletNullifier.ts
+++ b/packages/core/src/actions/getWalletNullifier.ts
@@ -1,0 +1,11 @@
+import type { RenegadeConfig } from "../createConfig.js";
+import { stringifyForWasm } from "../utils/bigJSON.js";
+import { getBackOfQueueWallet } from "./getBackOfQueueWallet.js";
+
+/**
+ * Compute the nullifier for the relayer's current view of the wallet.
+ */
+export async function getWalletNullifier(config: RenegadeConfig): Promise<boolean> {
+    const wallet = await getBackOfQueueWallet(config);
+    return config.utils.wallet_nullifier(stringifyForWasm(wallet));
+}

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -82,47 +82,39 @@ export {
     type GetExternalMatchQuoteReturnType,
     getExternalMatchQuote,
 } from "../actions/getExternalMatchQuote.js";
-
 export {
     type GetNetworkOrdersErrorType,
     type GetNetworkOrdersReturnType,
     getNetworkOrders,
 } from "../actions/getNetworkOrders.js";
-
 export {
     type GetOpenOrdersErrorType,
     type GetOpenOrdersParameters,
     type GetOpenOrdersReturnType,
     getOpenOrders,
 } from "../actions/getOpenOrders.js";
-
 export {
     type GetOrderParameters,
     type GetOrderReturnType,
     getOrder,
 } from "../actions/getOrder.js";
-
 export {
     type GetOrderHistoryErrorType,
     type GetOrderHistoryReturnType,
     getOrderHistory,
 } from "../actions/getOrderHistory.js";
-
 export {
     type GetOrderMatchingPoolParameters,
     type GetOrderMatchingPoolReturnType,
     getOrderMatchingPool,
 } from "../actions/getOrderMatchingPool.js";
-
 export {
     type GetOrderMetadataErrorType,
     type GetOrderMetadataParameters,
     type GetOrderMetadataReturnType,
     getOrderMetadata,
 } from "../actions/getOrderMetadata.js";
-
 export { type GetOrdersReturnType, getOrders } from "../actions/getOrders.js";
-
 export {
     type GetPkRootReturnType,
     type GetPkRootScalarsReturnType,
@@ -169,6 +161,7 @@ export {
     type GetWalletMatchableOrderIdsReturnType,
     getWalletMatchableOrderIds,
 } from "../actions/getWalletMatchableOrderIds.js";
+export { getWalletNullifier } from "../actions/getWalletNullifier.js";
 export {
     type LookupWalletReturnType,
     lookupWallet,

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -140,7 +140,6 @@ export {
     type GetTaskQueueReturnType,
     getTaskQueue,
 } from "../actions/getTaskQueue.js";
-
 export {
     type GetTaskStatusParameters,
     type GetTaskStatusReturnType,
@@ -151,25 +150,23 @@ export {
     type GetTokenPricesReturnType,
     getTokenPrices,
 } from "../actions/getTokenPrices.js";
-
 export {
     type GetWalletFromRelayerErrorType as GetWalletErrorType,
     type GetWalletFromRelayerParameters,
     type GetWalletFromRelayerReturnType,
     getWalletFromRelayer,
 } from "../actions/getWalletFromRelayer.js";
-
 export {
     type GetWalletIdReturnType,
     getWalletId,
 } from "../actions/getWalletId.js";
-
 export {
     type GetWalletMatchableOrderIdsErrorType,
     type GetWalletMatchableOrderIdsParameters,
     type GetWalletMatchableOrderIdsReturnType,
     getWalletMatchableOrderIds,
 } from "../actions/getWalletMatchableOrderIds.js";
+export { getWalletNullifier } from "../actions/getWalletNullifier.js";
 
 export {
     type LookupWalletReturnType,

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -1,19 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
-* @param {string} path
-* @param {any} headers
-* @param {string} body
-* @param {string} key
-* @returns {string}
-*/
-export function create_request_signature(path: string, headers: any, body: string, key: string): string;
-/**
-* @param {string} b64_key
-* @returns {string}
-*/
-export function b64_to_hex_hmac_key(b64_key: string): string;
-/**
 * @param {string} wallet_id
 * @param {string} blinder_seed
 * @param {string} share_seed
@@ -24,45 +11,6 @@ export function b64_to_hex_hmac_key(b64_key: string): string;
 */
 export function find_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
 /**
-* @param {Function} sign_message
-* @returns {Promise<any>}
-*/
-export function generate_wallet_secrets(sign_message: Function): Promise<any>;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
-/**
-* @param {string} seed
-* @param {bigint} nonce
-* @returns {any}
-*/
-export function get_pk_root(seed: string, nonce: bigint): any;
-/**
-* @param {string | undefined} [seed]
-* @param {bigint | undefined} [nonce]
-* @param {string | undefined} [public_key]
-* @returns {any[]}
-*/
-export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: string): any[];
-/**
-* @param {string} seed
-* @returns {any}
-*/
-export function get_symmetric_key(seed: string): any;
-/**
-* @param {string} wallet_id
-* @param {string} blinder_seed
-* @param {string} share_seed
-* @param {string} pk_root
-* @param {string} sk_match
-* @param {string} symmetric_key
-* @returns {Promise<any>}
-*/
-export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
-/**
 * @param {string} seed
 * @returns {any}
 */
@@ -72,16 +20,6 @@ export function create_wallet(seed: string): any;
 * @returns {any}
 */
 export function find_wallet(seed: string): any;
-/**
-* @param {string} seed
-* @returns {any}
-*/
-export function derive_blinder_share(seed: string): any;
-/**
-* @param {string} seed
-* @returns {any}
-*/
-export function wallet_id(seed: string): any;
 /**
 * @param {string | undefined} seed
 * @param {string} wallet_str
@@ -197,3 +135,70 @@ export function new_external_quote_request(base_mint: string, quote_mint: string
 * @returns {any}
 */
 export function assemble_external_match(do_gas_estimation: boolean, allow_shared: boolean, updated_order: string, sponsored_quote_response: string, receiver_address: string): any;
+/**
+* @param {string} wallet_id
+* @param {string} blinder_seed
+* @param {string} share_seed
+* @param {string} pk_root
+* @param {string} sk_match
+* @param {string} symmetric_key
+* @returns {Promise<any>}
+*/
+export function create_external_wallet(wallet_id: string, blinder_seed: string, share_seed: string, pk_root: string, sk_match: string, symmetric_key: string): Promise<any>;
+/**
+* @param {string} seed
+* @returns {any}
+*/
+export function derive_blinder_share(seed: string): any;
+/**
+* @param {string} seed
+* @returns {any}
+*/
+export function wallet_id(seed: string): any;
+/**
+* @param {string} wallet_str
+* @returns {any}
+*/
+export function wallet_nullifier(wallet_str: string): any;
+/**
+* @param {Function} sign_message
+* @returns {Promise<any>}
+*/
+export function generate_wallet_secrets(sign_message: Function): Promise<any>;
+/**
+* @param {string} path
+* @param {any} headers
+* @param {string} body
+* @param {string} key
+* @returns {string}
+*/
+export function create_request_signature(path: string, headers: any, body: string, key: string): string;
+/**
+* @param {string} b64_key
+* @returns {string}
+*/
+export function b64_to_hex_hmac_key(b64_key: string): string;
+/**
+* @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function derive_sk_root_from_seed(seed: string, nonce: bigint): any;
+/**
+* @param {string} seed
+* @param {bigint} nonce
+* @returns {any}
+*/
+export function get_pk_root(seed: string, nonce: bigint): any;
+/**
+* @param {string | undefined} [seed]
+* @param {bigint | undefined} [nonce]
+* @param {string | undefined} [public_key]
+* @returns {any[]}
+*/
+export function get_pk_root_scalars(seed?: string, nonce?: bigint, public_key?: string): any[];
+/**
+* @param {string} seed
+* @returns {any}
+*/
+export function get_symmetric_key(seed: string): any;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.7'
+export const version = '0.9.8'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.6.13
+
+### Patch Changes
+
+- add getWalletNullifier action
+- Updated dependencies
+  - @renegade-fi/core@0.9.8
+
 ## 0.6.12
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.6.12",
+    "version": "0.6.13",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/node/src/clients/renegade/base.ts
+++ b/packages/node/src/clients/renegade/base.ts
@@ -28,6 +28,7 @@ import {
     getBackOfQueueWallet,
     getTaskQueuePaused,
     getWalletFromRelayer,
+    getWalletNullifier,
     lookupWallet,
     payFees,
     refreshWallet,
@@ -324,6 +325,10 @@ export class RenegadeClient {
 
     getWalletId() {
         return getWalletId(this.getConfig());
+    }
+
+    async getWalletNullifier() {
+        return getWalletNullifier(this.getConfig());
     }
 
     async getOrderHistory(parameters: GetOrderHistoryParameters) {

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.8
+  - @renegade-fi/token@0.0.27
+
 ## 0.0.26
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.8
+
 ## 0.6.22
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.22",
+    "version": "0.6.23",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.33
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.8
+
 ## 0.4.32
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.32",
+    "version": "0.4.33",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.8
+  - @renegade-fi/token@0.0.27
+
 ## 0.1.12
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.8
+
 ## 0.0.26
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",

--- a/wasm/src/circuit_types/wallet.rs
+++ b/wasm/src/circuit_types/wallet.rs
@@ -12,6 +12,9 @@ use super::{
 /// state
 pub type WalletShareStateCommitment = Scalar;
 
+/// Nullifier type alias for readability
+pub type Nullifier = Scalar;
+
 // --------------------
 // | Wallet Base Type |
 // --------------------

--- a/wasm/src/common/types.rs
+++ b/wasm/src/common/types.rs
@@ -3,11 +3,16 @@ use std::str::FromStr;
 use super::{keychain::KeyChain, keyed_list::KeyedList};
 use crate::{
     circuit_types::{
-        balance::Balance, compute_wallet_share_commitment, create_wallet_shares_from_private,
-        create_wallet_shares_with_randomness, elgamal::EncryptionKey, fixed_point::FixedPoint,
-        order::Order, wallet::WalletShareStateCommitment, SizedWallet as SizedCircuitWallet,
+        balance::Balance,
+        compute_wallet_share_commitment, create_wallet_shares_from_private,
+        create_wallet_shares_with_randomness,
+        elgamal::EncryptionKey,
+        fixed_point::FixedPoint,
+        order::Order,
+        wallet::{Nullifier, WalletShareStateCommitment},
+        SizedWallet as SizedCircuitWallet,
     },
-    helpers::{evaluate_hash_chain, PoseidonCSPRNG},
+    helpers::{compute_poseidon_hash, evaluate_hash_chain, PoseidonCSPRNG},
     types::Scalar,
     CLUSTER_SYMMETRIC_KEY_LENGTH, MAX_BALANCES, MAX_ORDERS, NUM_SCALARS,
 };
@@ -123,6 +128,11 @@ impl Wallet {
             &self.blinded_public_shares,
             &self.private_shares,
         )
+    }
+
+    /// Compute the wallet nullifier
+    pub fn get_wallet_nullifier(&self) -> Nullifier {
+        compute_poseidon_hash(&[self.get_wallet_share_commitment(), self.blinder])
     }
 
     // -----------

--- a/wasm/src/external_api/mod.rs
+++ b/wasm/src/external_api/mod.rs
@@ -3,3 +3,4 @@ pub mod create_wallet;
 pub mod find_wallet;
 pub mod http;
 pub mod types;
+pub mod wallet_utils;

--- a/wasm/src/external_api/wallet_utils.rs
+++ b/wasm/src/external_api/wallet_utils.rs
@@ -1,0 +1,37 @@
+//! Utility functions for working with wallets
+
+use itertools::Itertools;
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    common::derivation::{derive_blinder_seed, derive_sk_root_signing_key, derive_wallet_id},
+    helpers::{deserialize_wallet, PoseidonCSPRNG},
+};
+
+#[wasm_bindgen]
+pub fn derive_blinder_share(seed: &str) -> Result<JsValue, JsError> {
+    let sk_root = derive_sk_root_signing_key(seed, None)?;
+    let blinder_seed = derive_blinder_seed(&sk_root)?;
+    let mut blinder_csprng = PoseidonCSPRNG::new(blinder_seed);
+    let (blinder, blinder_private) = blinder_csprng
+        .next_tuple()
+        .ok_or(JsError::new("Failed to generate blinder tuple"))?;
+    let blinder_share = blinder - blinder_private;
+    Ok(JsValue::from_str(&blinder_share.to_biguint().to_string()))
+}
+
+#[wasm_bindgen]
+pub fn wallet_id(seed: &str) -> Result<JsValue, JsError> {
+    let sk_root = derive_sk_root_signing_key(seed, None)?;
+    let wallet_id = derive_wallet_id(&sk_root)?;
+    Ok(JsValue::from_str(&wallet_id.to_string()))
+}
+
+#[wasm_bindgen]
+pub fn wallet_nullifier(wallet_str: &str) -> Result<JsValue, JsError> {
+    let wallet = deserialize_wallet(wallet_str)?;
+    let nullifier = wallet.get_wallet_nullifier();
+    Ok(JsValue::bigint_from_str(
+        &nullifier.to_biguint().to_string(),
+    ))
+}


### PR DESCRIPTION
This PR adds an action for computing the nullifier of the current back-of-queue wallet.

### Testing
- [x] Use SDK to compute nullifier, check against on-chain events after updating wallet