### PR TITLE
core: actions: getWalletNullifier: fix return type

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.9.9
+
+### Patch Changes
+
+- fix getWalletNullifier return type
+
 ## 0.9.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.9.8",
+    "version": "0.9.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/actions/getWalletNullifier.ts
+++ b/packages/core/src/actions/getWalletNullifier.ts
@@ -5,7 +5,7 @@ import { getBackOfQueueWallet } from "./getBackOfQueueWallet.js";
 /**
  * Compute the nullifier for the relayer's current view of the wallet.
  */
-export async function getWalletNullifier(config: RenegadeConfig): Promise<boolean> {
+export async function getWalletNullifier(config: RenegadeConfig): Promise<bigint> {
     const wallet = await getBackOfQueueWallet(config);
     return config.utils.wallet_nullifier(stringifyForWasm(wallet));
 }

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.8'
+export const version = '0.9.9'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.6.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.9
+
 ## 0.6.13
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.6.13",
+    "version": "0.6.14",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/price-reporter
 
+## 0.0.28
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.9
+  - @renegade-fi/token@0.0.28
+
 ## 0.0.27
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.27",
+    "version": "0.0.28",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.6.24
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.9
+
 ## 0.6.23
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.23",
+    "version": "0.6.24",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.4.34
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.9
+
 ## 0.4.33
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/test",
-    "version": "0.4.33",
+    "version": "0.4.34",
     "description": "Testing helpers for Renegade",
     "private": true,
     "files": [

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.9
+  - @renegade-fi/token@0.0.28
+
 ## 0.1.13
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/token
 
+## 0.0.28
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.9.9
+
 ## 0.0.27
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.27",
+    "version": "0.0.28",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",


### PR DESCRIPTION
This PR fixes the return type of the new `getWalletNullifier` action to be a `bigint`. It was incorrectly set to `boolean` as a vestige of when the method would check if the nullifier was spent onchain.