### PR TITLE
external-package: migrate from typescript-external-match-client

### DIFF
--- a/examples/external-match/base-sepolia/package.json
+++ b/examples/external-match/base-sepolia/package.json
@@ -6,11 +6,11 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@renegade-fi/node": "latest",
+    "@renegade-fi/renegade-sdk": "latest",
     "viem": "latest"
   },
   "devDependencies": {
-    "tsx": "^4.20.3",
-    "typescript": "^5.0.3"
+    "tsx": "^4",
+    "typescript": "^5"
   }
 }

--- a/examples/external-match/basic/index.ts
+++ b/examples/external-match/basic/index.ts
@@ -1,6 +1,6 @@
-import { ExternalMatchClient } from "@renegade-fi/node";
+import { ExternalMatchClient, OrderSide } from "@renegade-fi/renegade-sdk";
 import { erc20Abi } from "viem";
-import { API_KEY, API_SECRET, chainId, owner, publicClient, walletClient } from "./env";
+import { API_KEY, API_SECRET, owner, publicClient, walletClient } from "./env";
 
 if (!API_KEY) {
     throw new Error("API_KEY is not set");
@@ -10,35 +10,37 @@ if (!API_SECRET) {
     throw new Error("API_SECRET is not set");
 }
 
-const client = ExternalMatchClient.new({
-    apiKey: API_KEY,
-    apiSecret: API_SECRET,
-    chainId,
-});
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 const WETH_ADDRESS = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
 const USDC_ADDRESS = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
 const quoteAmount = BigInt(2_000_000); // 2 USDC
-const side = "buy";
+const side = OrderSide.BUY;
 
 const order = {
-    base: WETH_ADDRESS,
-    quote: USDC_ADDRESS,
+    base_mint: WETH_ADDRESS,
+    quote_mint: USDC_ADDRESS,
     side,
-    quoteAmount,
+    quote_amount: quoteAmount,
 } as const;
 
 console.log("Fetching quote...");
 
-const quote = await client.getQuote({
-    order,
-});
+const quote = await client.requestQuote(order);
+
+if (!quote) {
+    console.error("No quote available, exiting...");
+    process.exit(1);
+}
 
 console.log("Assmbling quote...");
 
-const bundle = await client.assembleQuote({
-    quote,
-});
+const bundle = await client.assembleQuote(quote);
+
+if (!bundle) {
+    console.error("No bundle available, exiting...");
+    process.exit(1);
+}
 
 const tx = bundle.match_bundle.settlement_tx;
 
@@ -46,11 +48,12 @@ const tx = bundle.match_bundle.settlement_tx;
 
 const isSell = bundle.match_bundle.match_result.direction === "Sell";
 const address = isSell
-    ? bundle.match_bundle.match_result.base_mint
-    : bundle.match_bundle.match_result.quote_mint;
+    ? (bundle.match_bundle.match_result.base_mint as `0x${string}`)
+    : (bundle.match_bundle.match_result.quote_mint as `0x${string}`);
 const amount = isSell
     ? bundle.match_bundle.match_result.base_amount
     : bundle.match_bundle.match_result.quote_amount;
+const spender = tx.to as `0x${string}`;
 
 console.log("Checking allowance...");
 
@@ -58,7 +61,7 @@ const allowance = await publicClient.readContract({
     address,
     abi: erc20Abi,
     functionName: "allowance",
-    args: [owner, tx.to],
+    args: [owner, spender],
 });
 
 if (allowance < amount) {
@@ -67,7 +70,7 @@ if (allowance < amount) {
         address,
         abi: erc20Abi,
         functionName: "approve",
-        args: [tx.to, amount],
+        args: [spender, amount],
     });
     console.log("Submitting approve transaction...");
     await publicClient.waitForTransactionReceipt({
@@ -81,8 +84,8 @@ if (allowance < amount) {
 console.log("Submitting bundle...");
 
 const hash = await walletClient.sendTransaction({
-    to: tx.to,
-    data: tx.data,
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
     type: "eip1559",
 });
 

--- a/examples/external-match/basic/package.json
+++ b/examples/external-match/basic/package.json
@@ -6,11 +6,11 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@renegade-fi/node": "latest",
+    "@renegade-fi/renegade-sdk": "latest",
     "viem": "latest"
   },
   "devDependencies": {
-    "tsx": "^4.20.3",
-    "typescript": "^5.0.3"
+    "tsx": "^4",
+    "typescript": "^5"
   }
 }

--- a/examples/external-match/in-kind-gas-sponsorship/index.ts
+++ b/examples/external-match/in-kind-gas-sponsorship/index.ts
@@ -1,6 +1,6 @@
-import { ExternalMatchClient } from "@renegade-fi/node";
+import { ExternalMatchClient, OrderSide } from "@renegade-fi/renegade-sdk";
 import { erc20Abi } from "viem";
-import { API_KEY, API_SECRET, chainId, owner, publicClient, walletClient } from "./env";
+import { API_KEY, API_SECRET, owner, publicClient, walletClient } from "./env";
 
 if (!API_KEY) {
     throw new Error("API_KEY is not set");
@@ -10,30 +10,28 @@ if (!API_SECRET) {
     throw new Error("API_SECRET is not set");
 }
 
-const client = ExternalMatchClient.new({
-    apiKey: API_KEY,
-    apiSecret: API_SECRET,
-    chainId,
-});
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 const WETH_ADDRESS = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
 const USDC_ADDRESS = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
 const quoteAmount = BigInt(20_000_000); // 20 USDC
-const side = "sell";
+const side = OrderSide.SELL;
 
 const order = {
-    base: WETH_ADDRESS,
-    quote: USDC_ADDRESS,
+    base_mint: WETH_ADDRESS,
+    quote_mint: USDC_ADDRESS,
     side,
-    quoteAmount,
+    quote_amount: quoteAmount,
 } as const;
 
 console.log("Fetching quote...");
 
-const quote = await client.getQuote({
-    order,
-    disableGasSponsorship: false, // Note that this is false by default
-});
+const quote = await client.requestQuote(order);
+
+if (!quote) {
+    console.error("No quote available, exiting...");
+    process.exit(1);
+}
 
 const gasSponsorshipInfo = quote.gas_sponsorship_info?.gas_sponsorship_info;
 if (!gasSponsorshipInfo) {
@@ -43,9 +41,12 @@ console.log("Refund amount:", gasSponsorshipInfo.refund_amount);
 
 console.log("Assmbling quote...");
 
-const bundle = await client.assembleQuote({
-    quote,
-});
+const bundle = await client.assembleQuote(quote);
+
+if (!bundle) {
+    console.error("No bundle available, exiting...");
+    process.exit(1);
+}
 
 const tx = bundle.match_bundle.settlement_tx;
 
@@ -53,18 +54,19 @@ const tx = bundle.match_bundle.settlement_tx;
 
 const isSell = bundle.match_bundle.match_result.direction === "Sell";
 const address = isSell
-    ? bundle.match_bundle.match_result.base_mint
-    : bundle.match_bundle.match_result.quote_mint;
+    ? (bundle.match_bundle.match_result.base_mint as `0x${string}`)
+    : (bundle.match_bundle.match_result.quote_mint as `0x${string}`);
 const amount = isSell
     ? bundle.match_bundle.match_result.base_amount
     : bundle.match_bundle.match_result.quote_amount;
+const spender = tx.to as `0x${string}`;
 
 console.log("Checking allowance...");
 const allowance = await publicClient.readContract({
     address,
     abi: erc20Abi,
     functionName: "allowance",
-    args: [owner, tx.to],
+    args: [owner, spender],
 });
 
 if (allowance < amount) {
@@ -73,7 +75,7 @@ if (allowance < amount) {
         address,
         abi: erc20Abi,
         functionName: "approve",
-        args: [tx.to, amount],
+        args: [spender, amount],
     });
     console.log("Submitting approve transaction...");
     await publicClient.waitForTransactionReceipt({
@@ -87,8 +89,8 @@ if (allowance < amount) {
 console.log("Submitting bundle...");
 
 const hash = await walletClient.sendTransaction({
-    to: tx.to,
-    data: tx.data,
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
     type: "eip1559",
 });
 

--- a/examples/external-match/in-kind-gas-sponsorship/package.json
+++ b/examples/external-match/in-kind-gas-sponsorship/package.json
@@ -6,10 +6,11 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@renegade-fi/node": "latest",
+    "@renegade-fi/renegade-sdk": "latest",
     "viem": "latest"
   },
   "devDependencies": {
-    "typescript": "^5.0.3"
+    "tsx": "^4",
+    "typescript": "^5"
   }
 }

--- a/examples/external-match/native-gas-sponshorship/index.ts
+++ b/examples/external-match/native-gas-sponshorship/index.ts
@@ -1,6 +1,6 @@
-import { ExternalMatchClient } from "@renegade-fi/node";
+import { ExternalMatchClient, OrderSide } from "@renegade-fi/renegade-sdk";
 import { erc20Abi } from "viem";
-import { API_KEY, API_SECRET, chainId, owner, publicClient, walletClient } from "./env";
+import { API_KEY, API_SECRET, owner, publicClient, walletClient } from "./env";
 
 if (!API_KEY) {
     throw new Error("API_KEY is not set");
@@ -10,32 +10,28 @@ if (!API_SECRET) {
     throw new Error("API_SECRET is not set");
 }
 
-const client = ExternalMatchClient.new({
-    apiKey: API_KEY,
-    apiSecret: API_SECRET,
-    chainId,
-});
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 const WETH_ADDRESS = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
 const USDC_ADDRESS = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
 const quoteAmount = BigInt(20_000_000); // 20 USDC
-const side = "sell";
+const side = OrderSide.SELL;
 
 const order = {
-    base: WETH_ADDRESS,
-    quote: USDC_ADDRESS,
+    base_mint: WETH_ADDRESS,
+    quote_mint: USDC_ADDRESS,
     side,
-    quoteAmount,
+    quote_amount: quoteAmount,
 } as const;
 
 console.log("Fetching quote...");
 
-const quote = await client.getQuote({
-    order,
-    disableGasSponsorship: false, // Note that this is false by default
-    refundAddress: owner,
-    refundNativeEth: true,
-});
+const quote = await client.requestQuote(order);
+
+if (!quote) {
+    console.error("No quote available, exiting...");
+    process.exit(1);
+}
 
 const gasSponsorshipInfo = quote.gas_sponsorship_info?.gas_sponsorship_info;
 if (!gasSponsorshipInfo) {
@@ -45,9 +41,12 @@ console.log("Refund amount:", gasSponsorshipInfo.refund_amount);
 
 console.log("Assmbling quote...");
 
-const bundle = await client.assembleQuote({
-    quote,
-});
+const bundle = await client.assembleQuote(quote);
+
+if (!bundle) {
+    console.error("No bundle available, exiting...");
+    process.exit(1);
+}
 
 const tx = bundle.match_bundle.settlement_tx;
 
@@ -55,18 +54,19 @@ const tx = bundle.match_bundle.settlement_tx;
 
 const isSell = bundle.match_bundle.match_result.direction === "Sell";
 const address = isSell
-    ? bundle.match_bundle.match_result.base_mint
-    : bundle.match_bundle.match_result.quote_mint;
+    ? (bundle.match_bundle.match_result.base_mint as `0x${string}`)
+    : (bundle.match_bundle.match_result.quote_mint as `0x${string}`);
 const amount = isSell
     ? bundle.match_bundle.match_result.base_amount
     : bundle.match_bundle.match_result.quote_amount;
+const spender = tx.to as `0x${string}`;
 
 console.log("Checking allowance...");
 const allowance = await publicClient.readContract({
     address,
     abi: erc20Abi,
     functionName: "allowance",
-    args: [owner, tx.to],
+    args: [owner, spender],
 });
 
 if (allowance < amount) {
@@ -75,7 +75,7 @@ if (allowance < amount) {
         address,
         abi: erc20Abi,
         functionName: "approve",
-        args: [tx.to, amount],
+        args: [spender, amount],
     });
     console.log("Submitting approve transaction...");
     await publicClient.waitForTransactionReceipt({
@@ -89,8 +89,8 @@ if (allowance < amount) {
 console.log("Submitting bundle...");
 
 const hash = await walletClient.sendTransaction({
-    to: tx.to,
-    data: tx.data,
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
     type: "eip1559",
 });
 

--- a/examples/external-match/native-gas-sponshorship/package.json
+++ b/examples/external-match/native-gas-sponshorship/package.json
@@ -2,12 +2,15 @@
   "name": "example-external-match-native-gas-sponsorship",
   "private": true,
   "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
   "dependencies": {
-    "@renegade-fi/node": "latest",
+    "@renegade-fi/renegade-sdk": "latest",
     "viem": "latest"
   },
   "devDependencies": {
-    "tsx": "^4.20.3",
-    "typescript": "^5.0.3"
+    "tsx": "^4",
+    "typescript": "^5"
   }
 }

--- a/examples/external-match/order-book-depth/README.md
+++ b/examples/external-match/order-book-depth/README.md
@@ -1,0 +1,7 @@
+# Order Book Depth External Match Example
+
+```bash
+bun run index.ts
+```
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/renegade-fi/typescript-sdk/tree/main/examples/external-match/order-book-depth)

--- a/examples/external-match/order-book-depth/env.ts
+++ b/examples/external-match/order-book-depth/env.ts
@@ -1,0 +1,27 @@
+import { createPublicClient, createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { arbitrumSepolia } from "viem/chains";
+
+const chainId = arbitrumSepolia.id;
+const privateKey = process.env.PKEY;
+if (!privateKey) {
+    throw new Error("PKEY is not set");
+}
+const account = privateKeyToAccount(privateKey as `0x${string}`);
+const owner = account.address;
+
+const API_KEY = process.env.API_KEY;
+const API_SECRET = process.env.API_SECRET;
+
+const publicClient = createPublicClient({
+    chain: arbitrumSepolia,
+    transport: http(),
+});
+
+const walletClient = createWalletClient({
+    account,
+    chain: arbitrumSepolia,
+    transport: http(),
+});
+
+export { account, chainId, publicClient, walletClient, API_KEY, API_SECRET, owner };

--- a/examples/external-match/order-book-depth/index.ts
+++ b/examples/external-match/order-book-depth/index.ts
@@ -1,0 +1,19 @@
+import { ExternalMatchClient } from "@renegade-fi/renegade-sdk";
+import { API_KEY, API_SECRET } from "./env";
+
+if (!API_KEY) {
+    throw new Error("API_KEY is not set");
+}
+
+if (!API_SECRET) {
+    throw new Error("API_SECRET is not set");
+}
+
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
+
+// Example base token mint (WETH)
+const WETH = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
+
+const depth = await client.getOrderBookDepth(WETH);
+
+console.log(depth);

--- a/examples/external-match/order-book-depth/package.json
+++ b/examples/external-match/order-book-depth/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "example-external-match-order-book-depth",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@renegade-fi/renegade-sdk": "latest",
+    "viem": "latest"
+  },
+  "devDependencies": {
+    "tsx": "^4",
+    "typescript": "^5"
+  }
+}

--- a/examples/external-match/order-book-depth/tsconfig.json
+++ b/examples/external-match/order-book-depth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "useDefineForClassFields": true,
+        "module": "ESNext",
+        "lib": ["ESNext", "DOM"],
+        "moduleResolution": "Node",
+        "strict": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "esModuleInterop": true,
+        "noEmit": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "skipLibCheck": true
+    },
+    "include": ["src"]
+}

--- a/examples/external-match/supported-tokens/index.ts
+++ b/examples/external-match/supported-tokens/index.ts
@@ -1,5 +1,5 @@
-import { ExternalMatchClient } from "@renegade-fi/node";
-import { API_KEY, API_SECRET, chainId } from "./env";
+import { ExternalMatchClient } from "@renegade-fi/renegade-sdk";
+import { API_KEY, API_SECRET } from "./env";
 
 if (!API_KEY) {
     throw new Error("API_KEY is not set");
@@ -9,11 +9,7 @@ if (!API_SECRET) {
     throw new Error("API_SECRET is not set");
 }
 
-const client = ExternalMatchClient.new({
-    apiKey: API_KEY,
-    apiSecret: API_SECRET,
-    chainId,
-});
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 const response = await client.getSupportedTokens();
 const tickers = response.tokens.map((token) => token.symbol);

--- a/examples/external-match/supported-tokens/package.json
+++ b/examples/external-match/supported-tokens/package.json
@@ -6,11 +6,11 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@renegade-fi/node": "latest",
+    "@renegade-fi/renegade-sdk": "latest",
     "viem": "latest"
   },
   "devDependencies": {
-    "tsx": "^4.20.3",
-    "typescript": "^5.0.3"
+    "tsx": "^4",
+    "typescript": "^5"
   }
 }

--- a/examples/external-match/token-prices/README.md
+++ b/examples/external-match/token-prices/README.md
@@ -4,4 +4,4 @@
 bun run index.ts
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/renegade-fi/typescript-sdk/tree/main/examples/external-match/supported-tokens)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/renegade-fi/typescript-sdk/tree/main/examples/external-match/token-prices)

--- a/examples/external-match/token-prices/index.ts
+++ b/examples/external-match/token-prices/index.ts
@@ -1,5 +1,5 @@
-import { ExternalMatchClient } from "@renegade-fi/node";
-import { API_KEY, API_SECRET, chainId } from "./env";
+import { ExternalMatchClient } from "@renegade-fi/renegade-sdk";
+import { API_KEY, API_SECRET } from "./env";
 
 if (!API_KEY) {
     throw new Error("API_KEY is not set");
@@ -9,11 +9,7 @@ if (!API_SECRET) {
     throw new Error("API_SECRET is not set");
 }
 
-const client = ExternalMatchClient.new({
-    apiKey: API_KEY,
-    apiSecret: API_SECRET,
-    chainId,
-});
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 const response = await client.getTokenPrices();
 

--- a/examples/external-match/token-prices/package.json
+++ b/examples/external-match/token-prices/package.json
@@ -6,11 +6,11 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@renegade-fi/node": "latest",
+    "@renegade-fi/renegade-sdk": "latest",
     "viem": "latest"
   },
   "devDependencies": {
-    "tsx": "^4.20.3",
-    "typescript": "^5.0.3"
+    "tsx": "^4",
+    "typescript": "^5"
   }
 }

--- a/packages/external-match/CHANGELOG.md
+++ b/packages/external-match/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @renegade-fi/renegade-sdk
+
+## 0.1.9
+
+### Patch Changes
+
+- chore: migrated to monorepo

--- a/packages/external-match/README.md
+++ b/packages/external-match/README.md
@@ -1,0 +1,31 @@
+# Renegade External Match Client
+
+A TypeScript client for interacting with the Renegade Darkpool's External Match API.
+
+## Installation
+
+```bash
+# Using npm
+npm install @renegade-fi/renegade-sdk
+
+# Using yarn
+yarn add @renegade-fi/renegade-sdk
+
+# Using bun
+bun add @renegade-fi/renegade-sdk
+```
+
+## Usage
+
+See the [examples](examples) for usage examples.
+
+## Documentation
+
+See the following resources for more information:
+- [Examples From the Existing SDK](https://github.com/renegade-fi/typescript-sdk/tree/main/examples)
+- [Renegade Docs](https://docs.renegade.fi/technical-reference/typescript-sdk#external-atomic-matching)
+- [OpenAPI spec](https://github.com/renegade-fi/renegade-docs/blob/main/api-specs/external-match-openapi.yaml)
+
+## License
+
+MIT

--- a/packages/external-match/package.json
+++ b/packages/external-match/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@renegade-fi/renegade-sdk",
+    "version": "0.1.8",
+    "description": "A TypeScript client for interacting with the Renegade Darkpool API",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/renegade-fi/typescript-sdk.git",
+        "directory": "packages/external-match"
+    },
+    "files": [
+        "dist/**",
+        "!dist/**/*.tsbuildinfo",
+        "src/**/*.ts",
+        "!src/**/*.test.ts",
+        "!src/**/*.test-d.ts"
+    ],
+    "sideEffects": false,
+    "type": "module",
+    "main": "./dist/esm/exports/index.js",
+    "types": "./dist/types/exports/index.d.ts",
+    "typings": "./dist/types/exports/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/types/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "scripts": {
+        "build": "pnpm run clean && pnpm run build:esm+types",
+        "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist --declaration --declarationMap --declarationDir ./dist/types",
+        "clean": "rm -rf dist tsconfig.tsbuildinfo",
+        "typecheck": "tsc --noEmit"
+    },
+    "devDependencies": {
+        "@types/json-bigint": "^1.0.4"
+    },
+    "dependencies": {
+        "@noble/hashes": "^1.7.1",
+        "json-bigint": "^1.0.0",
+        "viem": "^2.23.15"
+    },
+    "keywords": [],
+    "author": ""
+}

--- a/packages/external-match/package.json
+++ b/packages/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/renegade-sdk",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "A TypeScript client for interacting with the Renegade Darkpool API",
     "repository": {
         "type": "git",

--- a/packages/external-match/src/client.ts
+++ b/packages/external-match/src/client.ts
@@ -1,0 +1,662 @@
+/**
+ * Client for interacting with the Renegade external matching API.
+ *
+ * This client handles authentication and provides methods for requesting quotes,
+ * assembling matches, and executing trades.
+ */
+
+import { RelayerHttpClient } from "./http.js";
+import {
+    type ApiSignedExternalQuote,
+    type AssembleExternalMatchRequest,
+    type ExternalMatchResponse,
+    type ExternalOrder,
+    type ExternalQuoteRequest,
+    type ExternalQuoteResponse,
+    MalleableExternalMatchResponse,
+    type OrderBookDepth,
+    type SignedExternalQuote,
+    type SupportedTokensResponse,
+    type TokenPrice,
+    type TokenPricesResponse,
+} from "./types/index.js";
+import { VERSION } from "./version.js";
+
+// Constants for API URLs
+const ARBITRUM_SEPOLIA_BASE_URL = "https://arbitrum-sepolia.auth-server.renegade.fi";
+const ARBITRUM_ONE_BASE_URL = "https://arbitrum-one.auth-server.renegade.fi";
+const BASE_SEPOLIA_BASE_URL = "https://base-sepolia.auth-server.renegade.fi";
+const BASE_MAINNET_BASE_URL = "https://base-mainnet.auth-server.renegade.fi";
+
+const ARBITRUM_SEPOLIA_RELAYER_URL = "https://arbitrum-sepolia.relayer.renegade.fi";
+const ARBITRUM_ONE_RELAYER_URL = "https://arbitrum-one.relayer.renegade.fi";
+const BASE_SEPOLIA_RELAYER_URL = "https://base-sepolia.relayer.renegade.fi";
+const BASE_MAINNET_RELAYER_URL = "https://base-mainnet.relayer.renegade.fi";
+
+// Header constants
+const RENEGADE_API_KEY_HEADER = "x-renegade-api-key";
+const RENEGADE_SDK_VERSION_HEADER = "x-renegade-sdk-version";
+
+// API Routes
+const REQUEST_EXTERNAL_QUOTE_ROUTE = "/v0/matching-engine/quote";
+const ASSEMBLE_EXTERNAL_MATCH_ROUTE = "/v0/matching-engine/assemble-external-match";
+/**
+ * The route used to assemble an external match into a malleable bundle
+ */
+const ASSEMBLE_MALLEABLE_EXTERNAL_MATCH_ROUTE =
+    "/v0/matching-engine/assemble-malleable-external-match";
+const ORDER_BOOK_DEPTH_ROUTE = "/v0/order_book/depth";
+/** Returns the supported tokens list */
+const SUPPORTED_TOKENS_ROUTE = "/v0/supported-tokens";
+/** Returns the token prices */
+const TOKEN_PRICES_ROUTE = "/v0/token-prices";
+
+// Query Parameters
+const DISABLE_GAS_SPONSORSHIP_QUERY_PARAM = "disable_gas_sponsorship";
+const GAS_REFUND_ADDRESS_QUERY_PARAM = "refund_address";
+const REFUND_NATIVE_ETH_QUERY_PARAM = "refund_native_eth";
+
+/**
+ * Get the SDK version string.
+ *
+ * @returns The SDK version prefixed with "typescript-v"
+ */
+function getSdkVersion(): string {
+    return `typescript-v${VERSION}`;
+}
+
+/**
+ * Options for requesting a quote.
+ */
+export class RequestQuoteOptions {
+    disableGasSponsorship = false;
+    gasRefundAddress?: string;
+    refundNativeEth = false;
+
+    /**
+     * Create a new instance of RequestQuoteOptions.
+     */
+    static new(): RequestQuoteOptions {
+        return new RequestQuoteOptions();
+    }
+
+    /**
+     * Set whether gas sponsorship should be disabled.
+     */
+    withGasSponsorshipDisabled(disableGasSponsorship: boolean): RequestQuoteOptions {
+        this.disableGasSponsorship = disableGasSponsorship;
+        return this;
+    }
+
+    /**
+     * Set the gas refund address.
+     */
+    withGasRefundAddress(gasRefundAddress: string): RequestQuoteOptions {
+        this.gasRefundAddress = gasRefundAddress;
+        return this;
+    }
+
+    /**
+     * Set whether to refund in native ETH.
+     */
+    withRefundNativeEth(refundNativeEth: boolean): RequestQuoteOptions {
+        this.refundNativeEth = refundNativeEth;
+        return this;
+    }
+
+    /**
+     * Build the request path with query parameters.
+     */
+    buildRequestPath(): string {
+        const params = new URLSearchParams();
+        params.set(DISABLE_GAS_SPONSORSHIP_QUERY_PARAM, this.disableGasSponsorship.toString());
+        if (this.gasRefundAddress) {
+            params.set(GAS_REFUND_ADDRESS_QUERY_PARAM, this.gasRefundAddress);
+        }
+
+        if (this.refundNativeEth) {
+            params.set(REFUND_NATIVE_ETH_QUERY_PARAM, this.refundNativeEth.toString());
+        }
+
+        return `${REQUEST_EXTERNAL_QUOTE_ROUTE}?${params.toString()}`;
+    }
+}
+
+/**
+ * Options for assembling an external match.
+ */
+export class AssembleExternalMatchOptions {
+    doGasEstimation = false;
+    allowShared = false;
+    receiverAddress?: string;
+    updatedOrder?: ExternalOrder;
+    requestGasSponsorship = false;
+    gasRefundAddress?: string;
+
+    /**
+     * Create a new instance of AssembleExternalMatchOptions.
+     */
+    static new(): AssembleExternalMatchOptions {
+        return new AssembleExternalMatchOptions();
+    }
+
+    /**
+     * Set whether to do gas estimation.
+     */
+    withGasEstimation(doGasEstimation: boolean): AssembleExternalMatchOptions {
+        this.doGasEstimation = doGasEstimation;
+        return this;
+    }
+
+    /**
+     * Set whether to allow shared gas sponsorship.
+     */
+    withAllowShared(allowShared: boolean): AssembleExternalMatchOptions {
+        this.allowShared = allowShared;
+        return this;
+    }
+
+    /**
+     * Set the receiver address.
+     */
+    withReceiverAddress(receiverAddress: string): AssembleExternalMatchOptions {
+        this.receiverAddress = receiverAddress;
+        return this;
+    }
+
+    /**
+     * Set the updated order.
+     */
+    withUpdatedOrder(updatedOrder: ExternalOrder): AssembleExternalMatchOptions {
+        this.updatedOrder = updatedOrder;
+        return this;
+    }
+
+    /**
+     * Set whether to request gas sponsorship.
+     * @deprecated Request gas sponsorship when requesting a quote instead
+     */
+    withGasSponsorship(requestGasSponsorship: boolean): AssembleExternalMatchOptions {
+        this.requestGasSponsorship = requestGasSponsorship;
+        return this;
+    }
+
+    /**
+     * Set the gas refund address.
+     * @deprecated Request gas sponsorship when requesting a quote instead
+     */
+    withGasRefundAddress(gasRefundAddress: string): AssembleExternalMatchOptions {
+        this.gasRefundAddress = gasRefundAddress;
+        return this;
+    }
+
+    /**
+     * Build the request path with query parameters.
+     */
+    buildRequestPath(): string {
+        // If no query parameters are needed, return the base path
+        if (!this.requestGasSponsorship && !this.gasRefundAddress) {
+            return ASSEMBLE_EXTERNAL_MATCH_ROUTE;
+        }
+
+        const params = new URLSearchParams();
+        if (this.requestGasSponsorship) {
+            // We only write this query parameter if it was explicitly set
+            params.set(
+                DISABLE_GAS_SPONSORSHIP_QUERY_PARAM,
+                (!this.requestGasSponsorship).toString(),
+            );
+        }
+
+        if (this.gasRefundAddress) {
+            params.set(GAS_REFUND_ADDRESS_QUERY_PARAM, this.gasRefundAddress);
+        }
+
+        return `${ASSEMBLE_EXTERNAL_MATCH_ROUTE}?${params.toString()}`;
+    }
+}
+
+/**
+ * Options for assembling a malleable external match.
+ */
+export class AssembleMalleableExternalMatchOptions extends AssembleExternalMatchOptions {
+    /**
+     * Create a new instance of AssembleExternalMatchOptions.
+     */
+    static override new(): AssembleMalleableExternalMatchOptions {
+        return new AssembleMalleableExternalMatchOptions();
+    }
+    /**
+     * Build the request path with query parameters.
+     */
+    override buildRequestPath(): string {
+        // If no query parameters are needed, return the base path
+        if (!this.requestGasSponsorship && !this.gasRefundAddress) {
+            return ASSEMBLE_MALLEABLE_EXTERNAL_MATCH_ROUTE;
+        }
+
+        const params = new URLSearchParams();
+        if (this.requestGasSponsorship) {
+            // We only write this query parameter if it was explicitly set
+            params.set(
+                DISABLE_GAS_SPONSORSHIP_QUERY_PARAM,
+                (!this.requestGasSponsorship).toString(),
+            );
+        }
+
+        if (this.gasRefundAddress) {
+            params.set(GAS_REFUND_ADDRESS_QUERY_PARAM, this.gasRefundAddress);
+        }
+
+        return `${ASSEMBLE_MALLEABLE_EXTERNAL_MATCH_ROUTE}?${params.toString()}`;
+    }
+}
+
+/**
+ * Error thrown by the ExternalMatchClient.
+ */
+export class ExternalMatchClientError extends Error {
+    statusCode?: number;
+
+    constructor(message: string, statusCode?: number) {
+        super(message);
+        this.name = "ExternalMatchClientError";
+        this.statusCode = statusCode;
+    }
+}
+
+/**
+ * Client for interacting with the Renegade external matching API.
+ */
+export class ExternalMatchClient {
+    private apiKey: string;
+    private httpClient: RelayerHttpClient;
+    private relayerHttpClient: RelayerHttpClient;
+
+    /**
+     * Initialize a new ExternalMatchClient.
+     *
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @param baseUrl The base URL of the Renegade API
+     */
+    constructor(apiKey: string, apiSecret: string, baseUrl: string, relayerUrl: string) {
+        this.apiKey = apiKey;
+        this.httpClient = new RelayerHttpClient(baseUrl, apiSecret);
+        this.relayerHttpClient = new RelayerHttpClient(relayerUrl);
+    }
+
+    /**
+     * Create a new client configured for the Arbitrum Sepolia testnet.
+     *
+     * @deprecated Use {@link ExternalMatchClient.newArbitrumSepoliaClient} instead
+     */
+    static newSepoliaClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return ExternalMatchClient.newArbitrumSepoliaClient(apiKey, apiSecret);
+    }
+
+    /**
+     * Create a new client configured for the Arbitrum Sepolia testnet.
+     *
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @param relayerUrl The relayer URL for the client
+     * @returns A new ExternalMatchClient configured for Sepolia
+     */
+    static newArbitrumSepoliaClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(
+            apiKey,
+            apiSecret,
+            ARBITRUM_SEPOLIA_BASE_URL,
+            ARBITRUM_SEPOLIA_RELAYER_URL,
+        );
+    }
+
+    /**
+     * Create a new client configured for the Base Sepolia testnet.
+     *
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @returns A new ExternalMatchClient configured for Sepolia
+     */
+    static newBaseSepoliaClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(
+            apiKey,
+            apiSecret,
+            BASE_SEPOLIA_BASE_URL,
+            BASE_SEPOLIA_RELAYER_URL,
+        );
+    }
+
+    /**
+     * Create a new client configured for the Arbitrum One mainnet.
+     *
+     * @deprecated Use {@link ExternalMatchClient.newArbitrumOneClient} instead
+     */
+    static newMainnetClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return ExternalMatchClient.newArbitrumOneClient(apiKey, apiSecret);
+    }
+
+    /**
+     * Create a new client configured for the Arbitrum One mainnet.
+     *
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @returns A new ExternalMatchClient configured for mainnet
+     */
+    static newArbitrumOneClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(
+            apiKey,
+            apiSecret,
+            ARBITRUM_ONE_BASE_URL,
+            ARBITRUM_ONE_RELAYER_URL,
+        );
+    }
+
+    /**
+     * Create a new client configured for the Base mainnet.
+     *
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @returns A new ExternalMatchClient configured for mainnet
+     */
+    static newBaseMainnetClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(
+            apiKey,
+            apiSecret,
+            BASE_MAINNET_BASE_URL,
+            BASE_MAINNET_RELAYER_URL,
+        );
+    }
+
+    /**
+     * Request a quote for the given order.
+     *
+     * @param order The order to request a quote for
+     * @returns A promise that resolves to a signed quote if one is available, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async requestQuote(order: ExternalOrder): Promise<SignedExternalQuote | null> {
+        return this.requestQuoteWithOptions(order, RequestQuoteOptions.new());
+    }
+
+    /**
+     * Request a quote for the given order with custom options.
+     *
+     * @param order The order to request a quote for
+     * @param options Custom options for the quote request
+     * @returns A promise that resolves to a signed quote if one is available, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async requestQuoteWithOptions(
+        order: ExternalOrder,
+        options: RequestQuoteOptions,
+    ): Promise<SignedExternalQuote | null> {
+        const request: ExternalQuoteRequest = {
+            external_order: order,
+        };
+
+        const path = options.buildRequestPath();
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.httpClient.post<ExternalQuoteResponse>(
+                path,
+                request,
+                headers,
+            );
+
+            // Handle 204 No Content (no quotes available)
+            if (response.status === 204 || !response.data) {
+                return null;
+            }
+
+            const quoteResp = response.data;
+            const signedQuote: SignedExternalQuote = {
+                quote: quoteResp.signed_quote.quote,
+                signature: quoteResp.signed_quote.signature,
+                gas_sponsorship_info: quoteResp.gas_sponsorship_info,
+            };
+
+            return signedQuote;
+        } catch (error: any) {
+            // Handle HTTP-related errors from fetch implementation
+            if (error.status === 204) {
+                return null;
+            }
+
+            throw new ExternalMatchClientError(
+                error.message || "Failed to request quote",
+                error.status,
+            );
+        }
+    }
+
+    /**
+     * Assemble a quote into a match bundle with default options.
+     *
+     * @param quote The signed quote to assemble
+     * @returns A promise that resolves to a match response if assembly succeeds, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async assembleQuote(quote: SignedExternalQuote): Promise<ExternalMatchResponse | null> {
+        return this.assembleQuoteWithOptions(quote, AssembleExternalMatchOptions.new());
+    }
+
+    /**
+     * Assemble a quote into a match bundle with custom options.
+     *
+     * @param quote The signed quote to assemble
+     * @param options Custom options for quote assembly
+     * @returns A promise that resolves to a match response if assembly succeeds, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async assembleQuoteWithOptions(
+        quote: SignedExternalQuote,
+        options: AssembleExternalMatchOptions,
+    ): Promise<ExternalMatchResponse | null> {
+        const signedQuote: ApiSignedExternalQuote = {
+            quote: quote.quote,
+            signature: quote.signature,
+        };
+
+        const request: AssembleExternalMatchRequest = {
+            do_gas_estimation: options.doGasEstimation,
+            allow_shared: options.allowShared,
+            receiver_address: options.receiverAddress,
+            signed_quote: signedQuote,
+            updated_order: options.updatedOrder,
+        };
+
+        const path = options.buildRequestPath();
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.httpClient.post<ExternalMatchResponse>(
+                path,
+                request,
+                headers,
+            );
+
+            // Handle 204 No Content
+            if (response.status === 204 || !response.data) {
+                return null;
+            }
+
+            return response.data;
+        } catch (error: any) {
+            // Handle HTTP-related errors from fetch implementation
+            if (error.status === 204) {
+                return null;
+            }
+
+            throw new ExternalMatchClientError(
+                error.message || "Failed to assemble quote",
+                error.status,
+            );
+        }
+    }
+
+    /**
+     * Assemble a quote into a malleable match bundle with default options.
+     *
+     * @param quote The signed quote to assemble
+     * @returns A promise that resolves to a match response if assembly succeeds, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async assembleMalleableQuote(
+        quote: SignedExternalQuote,
+    ): Promise<MalleableExternalMatchResponse | null> {
+        return this.assembleMalleableQuoteWithOptions(
+            quote,
+            AssembleMalleableExternalMatchOptions.new(),
+        );
+    }
+
+    /**
+     * Assemble a quote into a malleable match bundle with custom options.
+     */
+    async assembleMalleableQuoteWithOptions(
+        quote: SignedExternalQuote,
+        options: AssembleMalleableExternalMatchOptions,
+    ): Promise<MalleableExternalMatchResponse | null> {
+        const signedQuote: ApiSignedExternalQuote = {
+            quote: quote.quote,
+            signature: quote.signature,
+        };
+
+        const request: AssembleExternalMatchRequest = {
+            do_gas_estimation: options.doGasEstimation,
+            allow_shared: options.allowShared,
+            receiver_address: options.receiverAddress,
+            signed_quote: signedQuote,
+            updated_order: options.updatedOrder,
+        };
+
+        const path = options.buildRequestPath();
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.httpClient.post<MalleableExternalMatchResponse>(
+                path,
+                request,
+                headers,
+            );
+
+            // Handle 204 No Content
+            if (response.status === 204 || !response.data) {
+                return null;
+            }
+
+            return new MalleableExternalMatchResponse(
+                response.data.match_bundle,
+                response.data.gas_sponsored,
+                response.data.gas_sponsorship_info,
+                response.data.base_amount,
+            );
+        } catch (error: any) {
+            // Handle HTTP-related errors from fetch implementation
+            if (error.status === 204) {
+                return null;
+            }
+
+            throw new ExternalMatchClientError(
+                error.message || "Failed to assemble quote",
+                error.status,
+            );
+        }
+    }
+
+    /**
+     * Get order book depth for a given base token mint.
+     *
+     * @param mint The base token mint address
+     * @returns A promise that resolves to the order book depth
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async getOrderBookDepth(mint: string): Promise<OrderBookDepth> {
+        const path = `${ORDER_BOOK_DEPTH_ROUTE}/${mint}`;
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.httpClient.get<OrderBookDepth>(path, headers);
+            if (response.status !== 200 || !response.data) {
+                throw new ExternalMatchClientError(
+                    "Failed to get order book depth",
+                    response.status,
+                );
+            }
+            return response.data;
+        } catch (error: any) {
+            throw new ExternalMatchClientError(
+                error.message || "Failed to get order book depth",
+                error.status,
+            );
+        }
+    }
+
+    /**
+     * Get a list of supported tokens for external matches
+     */
+    async getSupportedTokens(): Promise<SupportedTokensResponse> {
+        const path = `${SUPPORTED_TOKENS_ROUTE}`;
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.relayerHttpClient.get<SupportedTokensResponse>(
+                path,
+                headers,
+            );
+            if (response.status !== 200 || !response.data) {
+                throw new ExternalMatchClientError(
+                    "Failed to get supported tokens",
+                    response.status,
+                );
+            }
+            return response.data;
+        } catch (error: any) {
+            throw new ExternalMatchClientError(
+                error.message || "Failed to get supported tokens",
+                error.status,
+            );
+        }
+    }
+
+    /**
+     * Get a list of token prices
+     */
+    async getTokenPrices(): Promise<TokenPricesResponse> {
+        const path = `${TOKEN_PRICES_ROUTE}`;
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.relayerHttpClient.get<TokenPricesResponse>(path, headers);
+            if (response.status !== 200 || !response.data) {
+                throw new ExternalMatchClientError("Failed to get token prices", response.status);
+            }
+            return {
+                ...response.data,
+                token_prices: response.data.token_prices.map((tokenPrice: TokenPrice) => ({
+                    ...tokenPrice,
+                    price: Number.parseFloat(tokenPrice.price.toString()),
+                })),
+            };
+        } catch (error: any) {
+            throw new ExternalMatchClientError(
+                error.message || "Failed to get token prices",
+                error.status,
+            );
+        }
+    }
+    /**
+     * Get the headers required for API requests.
+     *
+     * @returns Headers containing the API key and SDK version
+     */
+    private getHeaders(): Record<string, string> {
+        return {
+            [RENEGADE_API_KEY_HEADER]: this.apiKey,
+            [RENEGADE_SDK_VERSION_HEADER]: getSdkVersion(),
+        };
+    }
+}

--- a/packages/external-match/src/http.ts
+++ b/packages/external-match/src/http.ts
@@ -1,0 +1,247 @@
+/**
+ * HTTP client for making authenticated requests to the Renegade relayer API.
+ * This client handles request signing and authentication using HMAC-SHA256.
+ */
+
+import { hmac } from "@noble/hashes/hmac";
+import { sha256 } from "@noble/hashes/sha2";
+import JSONBigInt from "json-bigint";
+
+// Constants for authentication
+export const RENEGADE_HEADER_PREFIX = "x-renegade";
+export const RENEGADE_AUTH_HEADER = "x-renegade-auth";
+export const RENEGADE_AUTH_EXPIRATION_HEADER = "x-renegade-auth-expiration";
+
+// Authentication constants
+const REQUEST_SIGNATURE_DURATION_MS = 10 * 1000; // 10 seconds in milliseconds
+
+// Configure JSON-BigInt for parsing and stringifying
+const jsonProcessor = JSONBigInt({
+    alwaysParseAsBig: true,
+    useNativeBigInt: true,
+});
+
+/**
+ * Parse JSON string that may contain BigInt values
+ */
+export const parseBigJSON = (data: string) => {
+    try {
+        return jsonProcessor.parse(data);
+    } catch (error) {
+        // If parsing fails, return original data
+        console.error("Failed to parse JSON with BigInt", error);
+        return data;
+    }
+};
+
+/**
+ * Stringify object that may contain BigInt values
+ */
+export const stringifyBigJSON = (data: any) => {
+    return jsonProcessor.stringify(data);
+};
+
+// Define interface for HTTP response similar to Axios response
+export interface HttpResponse<T = any> {
+    data: T;
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+}
+
+/**
+ * HTTP client for making authenticated requests to the Renegade relayer API.
+ */
+export class RelayerHttpClient {
+    private baseUrl: string;
+    private authKey?: Uint8Array;
+    private defaultHeaders: Record<string, string>;
+
+    /**
+     * Initialize a new RelayerHttpClient.
+     *
+     * @param baseUrl The base URL of the relayer API
+     * @param authKey The base64-encoded authentication key for request signing
+     */
+    constructor(baseUrl: string, authKey?: string) {
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+        if (authKey) {
+            this.authKey = this.decodeBase64(authKey);
+        }
+        this.defaultHeaders = {
+            "Content-Type": "application/json",
+        };
+    }
+
+    /**
+     * Make a GET request with custom headers.
+     *
+     * @param path The API endpoint path
+     * @param headers Additional headers to include
+     * @returns The API response
+     */
+    public async get<T>(
+        path: string,
+        headers: Record<string, string> = {},
+    ): Promise<HttpResponse<T>> {
+        return this.request<T>("GET", path, undefined, headers);
+    }
+
+    /**
+     * Make a POST request with custom headers.
+     *
+     * @param path The API endpoint path
+     * @param data The request body to send
+     * @param headers Additional headers to include
+     * @returns The API response
+     */
+    public async post<T, D = any>(
+        path: string,
+        data: D,
+        headers: Record<string, string> = {},
+    ): Promise<HttpResponse<T>> {
+        return this.request<T>("POST", path, data, headers);
+    }
+
+    /**
+     * Make an HTTP request with authentication.
+     *
+     * @param method The HTTP method
+     * @param path The API endpoint path
+     * @param data The request body data
+     * @param customHeaders Additional headers to include
+     * @returns The API response
+     */
+    private async request<T>(
+        method: string,
+        path: string,
+        data?: any,
+        customHeaders: Record<string, string> = {},
+    ): Promise<HttpResponse<T>> {
+        const urlPath = path.startsWith("/") ? path.slice(1) : path;
+        const url = new URL(urlPath, this.baseUrl);
+
+        // Prepare headers, and add authentication headers
+        const headers = { ...this.defaultHeaders, ...customHeaders };
+        let fullHeaders = headers;
+        if (this.authKey) {
+            fullHeaders = this.addAuthHeaders(url.pathname + url.search, headers, data);
+        }
+
+        // Prepare request body
+        let body: string | undefined;
+        if (data) {
+            body = typeof data === "string" ? data : stringifyBigJSON(data);
+        }
+
+        // Make the fetch request
+        const response = await fetch(url.toString(), {
+            method,
+            headers: fullHeaders,
+            body,
+        });
+
+        // Read the response body
+        let responseData: any;
+        const contentType = response.headers.get("content-type") || "";
+        if (contentType.includes("application/json")) {
+            const text = await response.text();
+            responseData = parseBigJSON(text);
+        } else {
+            responseData = await response.text();
+        }
+
+        // Convert headers to a simple object
+        const responseHeaders: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+            responseHeaders[key] = value;
+        });
+
+        // Return a response object similar to Axios response
+        return {
+            data: responseData,
+            status: response.status,
+            statusText: response.statusText,
+            headers: responseHeaders,
+        };
+    }
+
+    /**
+     * Add authentication headers to a request.
+     */
+    private addAuthHeaders(
+        path: string,
+        headers: Record<string, string>,
+        data?: any,
+    ): Record<string, string> {
+        // Add timestamp and expiry
+        const timestamp = Date.now();
+        const expiry = timestamp + REQUEST_SIGNATURE_DURATION_MS;
+        headers[RENEGADE_AUTH_EXPIRATION_HEADER] = expiry.toString();
+
+        // Compute the MAC signature and
+        const macDigest = this.computeRequestMac(path, headers, data);
+        headers[RENEGADE_AUTH_HEADER] = this.encodeBase64(Buffer.from(macDigest));
+        return headers;
+    }
+
+    /**
+     * Compute the HMAC-SHA256 MAC for a request.
+     *
+     * @param path The API endpoint path with query parameters
+     * @param headers The request headers
+     * @param data The request body data
+     * @returns The computed MAC digest
+     */
+    private computeRequestMac(
+        path: string,
+        headers: Record<string, string>,
+        data?: any,
+    ): Uint8Array {
+        if (!this.authKey) {
+            throw new Error("Auth key is not set");
+        }
+
+        // Initialize MAC with auth key
+        const mac = hmac.create(sha256, this.authKey);
+
+        // Add path to signature
+        const pathBytes = new TextEncoder().encode(path);
+        mac.update(pathBytes);
+
+        // Add Renegade headers to signature
+        const renegadeHeaders = Object.entries(headers)
+            .filter(([key]) => key.toLowerCase().startsWith(RENEGADE_HEADER_PREFIX))
+            .filter(([key]) => key.toLowerCase() !== RENEGADE_AUTH_HEADER.toLowerCase())
+            .sort(([a], [b]) => a.localeCompare(b));
+
+        for (const [key, value] of renegadeHeaders) {
+            mac.update(new TextEncoder().encode(key));
+            mac.update(new TextEncoder().encode(value.toString()));
+        }
+
+        // Add body to signature
+        let body = "";
+        if (data) {
+            body = typeof data === "string" ? data : stringifyBigJSON(data);
+        }
+        mac.update(new TextEncoder().encode(body));
+
+        // Return the digest
+        return mac.digest();
+    }
+
+    /**
+     * Decode a base64 string to a Uint8Array.
+     */
+    private decodeBase64(base64: string): Uint8Array {
+        return Buffer.from(base64, "base64");
+    }
+
+    /**
+     * Encode a Uint8Array or Buffer to a base64 string.
+     */
+    private encodeBase64(data: Uint8Array | Buffer): string {
+        return Buffer.from(data).toString("base64").replace(/=+$/, "");
+    }
+}

--- a/packages/external-match/src/index.ts
+++ b/packages/external-match/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Renegade External Match Client
+ * A TypeScript client for interacting with the Renegade Darkpool API.
+ */
+
+// Export main client
+export {
+    AssembleExternalMatchOptions,
+    ExternalMatchClient,
+    ExternalMatchClientError,
+    RequestQuoteOptions,
+} from "./client.js";
+
+// Export types
+export type {
+    ApiExternalAssetTransfer,
+    ApiExternalMatchResult,
+    ApiExternalQuote,
+    ApiSignedExternalQuote,
+    ApiTimestampedPrice,
+    AssembleExternalMatchRequest,
+    AtomicMatchApiBundle,
+    ExternalMatchResponse,
+    ExternalOrder,
+    ExternalQuoteRequest,
+    ExternalQuoteResponse,
+    FeeTake,
+    GasSponsorshipInfo,
+    SettlementTransaction,
+    SignedExternalQuote,
+    SignedGasSponsorshipInfo,
+} from "./types/index.js";
+
+// Export enums
+export { OrderSide } from "./types/index.js";

--- a/packages/external-match/src/types/fixedPoint.ts
+++ b/packages/external-match/src/types/fixedPoint.ts
@@ -1,0 +1,38 @@
+/** The number of bits to use for the fixed point precision */
+const FIXED_POINT_PRECISION_BITS = 63;
+
+/** `bigint` representing the fixed point precision shift value */
+const FIXED_POINT_PRECISION_SHIFT = BigInt(2) ** BigInt(FIXED_POINT_PRECISION_BITS);
+
+export class FixedPoint {
+    readonly value: bigint;
+
+    constructor(value: bigint) {
+        this.value = value;
+    }
+
+    /**
+     * Multiply a fixed point number by a bigint and return the floor
+     */
+    floorMulInt(amount: bigint): bigint {
+        const product = this.value * amount;
+        // BigInt division automatically floors for positive numbers
+        const floored = product / FIXED_POINT_PRECISION_SHIFT;
+        return floored;
+    }
+
+    /**
+     * Divide a bigint by a fixed point number and return the ceiling
+     */
+    static ceilDivInt(amount: bigint, fp: FixedPoint): bigint {
+        const numerator = amount * FIXED_POINT_PRECISION_SHIFT;
+        const quotient = numerator / fp.value;
+        const remainder = numerator % fp.value;
+
+        if (remainder === BigInt(0)) {
+            return quotient;
+        }
+
+        return quotient + BigInt(1);
+    }
+}

--- a/packages/external-match/src/types/index.ts
+++ b/packages/external-match/src/types/index.ts
@@ -1,0 +1,150 @@
+/**
+ * Type definitions for the Renegade Darkpool API.
+ */
+
+export enum OrderSide {
+    BUY = "Buy",
+    SELL = "Sell",
+}
+
+export interface ApiExternalAssetTransfer {
+    mint: string;
+    amount: bigint;
+}
+
+export interface ApiTimestampedPrice {
+    price: string;
+    timestamp: bigint;
+}
+
+export interface ApiExternalMatchResult {
+    quote_mint: string;
+    base_mint: string;
+    quote_amount: bigint;
+    base_amount: bigint;
+    direction: OrderSide;
+}
+
+export interface FeeTake {
+    relayer_fee: bigint;
+    protocol_fee: bigint;
+}
+
+export interface FeeTakeRate {
+    relayer_fee_rate: string;
+    protocol_fee_rate: string;
+}
+
+export interface ExternalOrder {
+    quote_mint: string;
+    base_mint: string;
+    side: OrderSide;
+    base_amount?: bigint;
+    quote_amount?: bigint;
+    exact_base_output?: bigint;
+    exact_quote_output?: bigint;
+    min_fill_size?: bigint;
+}
+
+export interface ApiExternalQuote {
+    order: ExternalOrder;
+    match_result: ApiExternalMatchResult;
+    fees: FeeTake;
+    send: ApiExternalAssetTransfer;
+    receive: ApiExternalAssetTransfer;
+    price: ApiTimestampedPrice;
+    timestamp: bigint;
+}
+
+export interface ApiSignedExternalQuote {
+    quote: ApiExternalQuote;
+    signature: string;
+}
+
+export interface GasSponsorshipInfo {
+    refund_amount: bigint;
+    refund_native_eth: boolean;
+    refund_address?: string;
+}
+
+export interface SignedGasSponsorshipInfo {
+    gas_sponsorship_info: GasSponsorshipInfo;
+    signature: string;
+}
+
+export interface SignedExternalQuote {
+    quote: ApiExternalQuote;
+    signature: string;
+    gas_sponsorship_info?: SignedGasSponsorshipInfo;
+}
+
+export interface SettlementTransaction {
+    tx_type: string;
+    to: string;
+    data: string;
+    value: string;
+}
+
+export interface AtomicMatchApiBundle {
+    match_result: ApiExternalMatchResult;
+    fees: FeeTake;
+    receive: ApiExternalAssetTransfer;
+    send: ApiExternalAssetTransfer;
+    settlement_tx: SettlementTransaction;
+}
+
+export interface ExternalQuoteRequest {
+    external_order: ExternalOrder;
+}
+
+export interface ExternalQuoteResponse {
+    signed_quote: ApiSignedExternalQuote;
+    gas_sponsorship_info?: SignedGasSponsorshipInfo;
+}
+
+export interface AssembleExternalMatchRequest {
+    do_gas_estimation?: boolean;
+    allow_shared?: boolean;
+    receiver_address?: string;
+    signed_quote: ApiSignedExternalQuote;
+    updated_order?: ExternalOrder;
+}
+
+export interface ExternalMatchResponse {
+    match_bundle: AtomicMatchApiBundle;
+    gas_sponsored: boolean;
+    gas_sponsorship_info?: GasSponsorshipInfo;
+}
+
+export interface DepthSideInfo {
+    total_quantity: bigint;
+    total_quantity_usd: number;
+}
+
+export interface OrderBookDepth {
+    price: number;
+    timestamp: number;
+    buy: DepthSideInfo;
+    sell: DepthSideInfo;
+}
+
+export interface ApiToken {
+    address: string;
+    symbol: string;
+}
+
+export interface SupportedTokensResponse {
+    tokens: ApiToken[];
+}
+
+export interface TokenPrice {
+    base_token: string;
+    quote_token: string;
+    price: number;
+}
+
+export interface TokenPricesResponse {
+    token_prices: TokenPrice[];
+}
+
+export * from "./malleableMatch.js";

--- a/packages/external-match/src/types/malleableMatch.ts
+++ b/packages/external-match/src/types/malleableMatch.ts
@@ -1,0 +1,436 @@
+import { bytesToHex, concatBytes, hexToBytes, numberToBytes, numberToHex } from "viem/utils";
+import { FixedPoint } from "./fixedPoint.js";
+import {
+    type ApiExternalAssetTransfer,
+    type FeeTakeRate,
+    type GasSponsorshipInfo,
+    OrderSide,
+    type SettlementTransaction,
+} from "./index.js";
+
+/** The length of an amount in the calldata, which is 32 bytes for a `uint256` */
+const AMOUNT_CALLDATA_LENGTH = 32;
+/**
+ * The offset of the quote amount in the calldata,
+ * which is `4` because it's the first calldata argument
+ * after the 4-byte function selector
+ */
+const QUOTE_AMOUNT_OFFSET = 4;
+/**
+ * The offset of the base amount in the calldata,
+ * which is `AMOUNT_CALLDATA_LENGTH` bytes after
+ * the quote amount as it is the next calldata argument
+ */
+const BASE_AMOUNT_OFFSET = QUOTE_AMOUNT_OFFSET + AMOUNT_CALLDATA_LENGTH;
+/** The address used to represent the native asset */
+const NATIVE_ASSET_ADDR = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/**
+ * The response type for requesting a malleable quote on an external order
+ */
+export class MalleableExternalMatchResponse {
+    /**
+     * The match bundle
+     */
+    match_bundle: MalleableAtomicMatchApiBundle;
+    /**
+     * The base amount chosen for the match
+     *
+     * If `undefined`, the base amount hasn't been selected and defaults to the order's maximum base amount.
+     *
+     * This field is not meant for client use directly, rather it is set by
+     * operating on the type and allows the response type to stay internally
+     * consistent
+     */
+    base_amount?: bigint;
+    /**
+     * The quote amount chosen for the match
+     *
+     * If `undefined`, the quote amount hasn't been selected and defaults to the
+     * quote amount implied by the maximum base amount and the price in the match result.
+     *
+     * This field is not meant for client use directly, rather it is set by
+     * operating on the type and allows the response type to stay internally
+     * consistent
+     */
+    quote_amount?: bigint;
+    /**
+     * Whether the match was sponsored
+     */
+    gas_sponsored: boolean;
+    /**
+     * The gas sponsorship info, if the match was sponsored
+     */
+    gas_sponsorship_info?: GasSponsorshipInfo;
+
+    constructor(
+        match_bundle: MalleableAtomicMatchApiBundle,
+        gas_sponsored: boolean,
+        gas_sponsorship_info?: GasSponsorshipInfo,
+        base_amount?: bigint,
+        quote_amount?: bigint,
+    ) {
+        this.match_bundle = match_bundle;
+        this.gas_sponsored = gas_sponsored;
+        this.gas_sponsorship_info = gas_sponsorship_info;
+        this.base_amount = base_amount;
+        this.quote_amount = quote_amount;
+    }
+
+    /**
+     * Set the `base_amount` of the `match_result`
+     *
+     * @returns The amount received at the given `base_amount`
+     */
+    public setBaseAmount(baseAmount: bigint) {
+        this.checkBaseAmount(baseAmount);
+
+        const impliedQuoteAmount = this.quoteAmount(baseAmount);
+
+        // Set the calldata
+        this.setBaseAmountCalldata(baseAmount);
+        this.setQuoteAmountCalldata(impliedQuoteAmount);
+
+        // Set the quote and base amounts on the response
+        this.base_amount = baseAmount;
+        this.quote_amount = impliedQuoteAmount;
+
+        return this.receiveAmount();
+    }
+
+    /**
+     * Set the calldata to use a given base amount
+     */
+    private setBaseAmountCalldata(baseAmount: bigint) {
+        const calldataBytes = hexToBytes(this.match_bundle.settlement_tx.data as `0x${string}`);
+
+        // Padded to 32 bytes
+        const baseAmountBytes = numberToBytes(baseAmount, { size: AMOUNT_CALLDATA_LENGTH });
+
+        const prefix = calldataBytes.slice(0, BASE_AMOUNT_OFFSET);
+        const suffix = calldataBytes.slice(
+            BASE_AMOUNT_OFFSET + AMOUNT_CALLDATA_LENGTH,
+            calldataBytes.length,
+        );
+
+        // Set the calldata and the tx value
+        const newCalldataBytes = concatBytes([prefix, baseAmountBytes, suffix]);
+        const newCalladata = bytesToHex(newCalldataBytes);
+        const value = this.isNativeEthSell() ? baseAmount : 0n;
+        const valueHex = numberToHex(value);
+
+        const newMatchBundle = {
+            ...this.match_bundle,
+            settlement_tx: {
+                ...this.match_bundle.settlement_tx,
+                data: newCalladata,
+                value: valueHex,
+            },
+        };
+
+        this.match_bundle = newMatchBundle;
+    }
+
+    /**
+     * Set the `quote_amount` of the `match_result`
+     *
+     * @returns The amount received at the given `quote_amount`
+     */
+    public setQuoteAmount(quoteAmount: bigint) {
+        const impliedBaseAmount = this.baseAmount(quoteAmount);
+        this.checkQuoteAmount(quoteAmount, impliedBaseAmount);
+
+        // Set the calldata
+        this.setQuoteAmountCalldata(quoteAmount);
+        this.setBaseAmountCalldata(impliedBaseAmount);
+
+        // Set the quote and base amounts on the response
+        this.quote_amount = quoteAmount;
+        this.base_amount = impliedBaseAmount;
+
+        return this.receiveAmount();
+    }
+
+    /**
+     * Set the calldata to use a given quote amount
+     */
+    private setQuoteAmountCalldata(quoteAmount: bigint) {
+        const calldataBytes = hexToBytes(this.match_bundle.settlement_tx.data as `0x${string}`);
+
+        // Padded to 32 bytes
+        const quoteAmountBytes = numberToBytes(quoteAmount, { size: AMOUNT_CALLDATA_LENGTH });
+
+        const prefix = calldataBytes.slice(0, QUOTE_AMOUNT_OFFSET);
+        const suffix = calldataBytes.slice(
+            QUOTE_AMOUNT_OFFSET + AMOUNT_CALLDATA_LENGTH,
+            calldataBytes.length,
+        );
+
+        // Set the calldata and the tx value
+        const newCalldataBytes = concatBytes([prefix, quoteAmountBytes, suffix]);
+        const newCalladata = bytesToHex(newCalldataBytes);
+
+        const newMatchBundle = {
+            ...this.match_bundle,
+            settlement_tx: {
+                ...this.match_bundle.settlement_tx,
+                data: newCalladata,
+            },
+        };
+
+        this.match_bundle = newMatchBundle;
+    }
+
+    /**
+     * Get the bounds on the base amount
+     *
+     * Returns an array [min, max] inclusive
+     */
+    public baseBounds(): [bigint, bigint] {
+        return [
+            this.match_bundle.match_result.min_base_amount,
+            this.match_bundle.match_result.max_base_amount,
+        ];
+    }
+
+    /**
+     * Get the bounds on the quote amount
+     *
+     * Returns an array [min, max] inclusive
+     */
+    public quoteBounds(): [bigint, bigint] {
+        const [minBase, maxBase] = this.baseBounds();
+        const price = this.getPriceFp();
+
+        const minQuote = price.floorMulInt(minBase);
+        const maxQuote = price.floorMulInt(maxBase);
+
+        return [minQuote, maxQuote];
+    }
+
+    /**
+     * Get the bounds on the quote amount for a given base amount.
+     *
+     * For an explanation of these bounds, see:
+     * https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/types/match.rs#L144-L174
+     */
+    public quoteBoundsForBase(baseAmount: bigint): [bigint, bigint] {
+        const [minQuote, maxQuote] = this.quoteBounds();
+
+        const price = this.getPriceFp();
+        const refQuote = price.floorMulInt(baseAmount);
+
+        const direction = this.match_bundle.match_result.direction;
+
+        const resolvedMinQuote = direction === OrderSide.BUY ? refQuote : minQuote;
+        const resolvedMaxQuote = direction === OrderSide.BUY ? maxQuote : refQuote;
+
+        return [resolvedMinQuote, resolvedMaxQuote];
+    }
+
+    /**
+     * Get the receive amount at the currently set base amount
+     */
+    public receiveAmount() {
+        return this.computeReceiveAmount(this.currentBaseAmount());
+    }
+
+    /**
+     * Get the receive amount at the given base amount
+     */
+    public receiveAmountAtBase(baseAmount: bigint) {
+        return this.computeReceiveAmount(baseAmount);
+    }
+
+    /**
+     * Get the receive amount at the given quote amount
+     */
+    public receiveAmountAtQuote(quoteAmount: bigint) {
+        const baseAmount = this.baseAmount(quoteAmount);
+        return this.computeReceiveAmount(baseAmount);
+    }
+
+    /**
+     * Get the send amount at the currently set base amount
+     */
+    public sendAmount() {
+        return this.computeSendAmount(this.currentBaseAmount());
+    }
+
+    /**
+     * Get the send amount at the given base amount
+     */
+    public sendAmountAtBase(baseAmount: bigint) {
+        return this.computeSendAmount(baseAmount);
+    }
+
+    /**
+     * Get the send amount at the given quote amount
+     */
+    public sendAmountAtQuote(quoteAmount: bigint) {
+        const baseAmount = this.baseAmount(quoteAmount);
+        return this.computeSendAmount(baseAmount);
+    }
+
+    /**
+     * Return whether the trade is a native ETH sell
+     */
+    public isNativeEthSell(): boolean {
+        const matchRes = this.match_bundle.match_result;
+        const isSell = matchRes.direction === OrderSide.SELL;
+        const isBaseEth = matchRes.base_mint.toLowerCase() === NATIVE_ASSET_ADDR.toLowerCase();
+
+        return isBaseEth && isSell;
+    }
+
+    /**
+     * Check a base amount is in the valid range
+     */
+    private checkBaseAmount(baseAmount: bigint) {
+        const [min, max] = this.baseBounds();
+
+        if (baseAmount < min || baseAmount > max) {
+            throw new Error(`Base amount ${baseAmount} is not in the valid range ${min} - ${max}`);
+        }
+    }
+
+    /**
+     * Check a quote amount is in the valid range for a given base amount.
+     *
+     * This is true if the quote amount is within the bounds implied by the min
+     * and max base amounts given the price in the match results, and the
+     * quote amount does not imply a price improvement over the price in
+     * the match result.
+     */
+    private checkQuoteAmount(quoteAmount: bigint, baseAmount: bigint) {
+        const [min, max] = this.quoteBoundsForBase(baseAmount);
+
+        if (quoteAmount < min || quoteAmount > max) {
+            throw new Error(
+                `Quote amount ${quoteAmount} is not in the valid range ${min} - ${max}`,
+            );
+        }
+    }
+
+    /**
+     * Get the current receive amount at the given base amount
+     *
+     * This is net of fees
+     */
+    private computeReceiveAmount(baseAmount: bigint) {
+        const matchRes = this.match_bundle.match_result;
+        let preSponsoredAmount =
+            matchRes.direction === OrderSide.BUY ? baseAmount : this.quoteAmount(baseAmount);
+
+        // Account for fees
+        const totalFee =
+            BigInt(this.match_bundle.fee_rates.protocol_fee_rate) +
+            BigInt(this.match_bundle.fee_rates.relayer_fee_rate);
+        const totalFeeAmount = new FixedPoint(totalFee).floorMulInt(preSponsoredAmount);
+        preSponsoredAmount -= totalFeeAmount;
+
+        // Account for gas sponsorship
+        if (this.gas_sponsorship_info && !this.gas_sponsorship_info.refund_native_eth) {
+            preSponsoredAmount += this.gas_sponsorship_info.refund_amount;
+        }
+
+        return preSponsoredAmount;
+    }
+
+    /**
+     * Get the current send amount at the given base amount
+     */
+    private computeSendAmount(baseAmount: bigint) {
+        const matchRes = this.match_bundle.match_result;
+        if (matchRes.direction === OrderSide.BUY) {
+            return this.quoteAmount(baseAmount);
+        }
+        return baseAmount;
+    }
+
+    /**
+     * Get the base amount at the given quote amount
+     */
+    private baseAmount(quoteAmount: bigint) {
+        const price = this.getPriceFp();
+        return FixedPoint.ceilDivInt(quoteAmount, price);
+    }
+
+    /**
+     * Get the quote amount at the given base amount
+     */
+    private quoteAmount(baseAmount: bigint) {
+        const price = this.getPriceFp();
+        return price.floorMulInt(baseAmount);
+    }
+
+    /**
+     * Get the current base amount
+     */
+    private currentBaseAmount() {
+        if (!this.base_amount) {
+            return this.match_bundle.match_result.max_base_amount;
+        }
+        return this.base_amount;
+    }
+
+    private getPriceFp() {
+        return new FixedPoint(BigInt(this.match_bundle.match_result.price_fp));
+    }
+}
+
+/**
+ * A bounded match result
+ */
+interface ApiBoundedMatchResult {
+    /**
+     * The mint of the quote token in the matched asset pair
+     */
+    quote_mint: string;
+    /**
+     * The mint of the base token in the matched asset pair
+     */
+    base_mint: string;
+    /**
+     * The price at which the match executes
+     */
+    price_fp: string;
+    /**
+     * The minimum base amount of the match
+     */
+    min_base_amount: bigint;
+    /**
+     * The maximum base amount of the match
+     */
+    max_base_amount: bigint;
+    /**
+     * The direction of the match
+     */
+    direction: OrderSide;
+}
+
+/**
+ * An atomic match settlement bundle using a malleable match result
+ *
+ * A malleable match result is one in which the exact `base_amount` swapped
+ * is not known at the time the proof is generated, and may be changed up until
+ * it is submitted on-chain. Instead, a bounded match result gives a
+ * `min_base_amount` and a `max_base_amount`, between which the `base_amount`
+ * may take any value
+ */
+interface MalleableAtomicMatchApiBundle {
+    /** The match result */
+    match_result: ApiBoundedMatchResult;
+    /** The fees owed by the external party */
+    fee_rates: FeeTakeRate;
+    /** The maximum amount that the external party will receive */
+    max_receive: ApiExternalAssetTransfer;
+    /** The minimum amount that the external party will receive */
+    min_receive: ApiExternalAssetTransfer;
+    /** The maximum amount that the external party will send */
+    max_send: ApiExternalAssetTransfer;
+    /** The minimum amount that the external party will send */
+    min_send: ApiExternalAssetTransfer;
+    /** The transaction which settles the match on-chain */
+    settlement_tx: SettlementTransaction;
+}

--- a/packages/external-match/src/version.ts
+++ b/packages/external-match/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * SDK version information
+ * This file is automatically updated during the build process
+ * Last updated: 2025-06-03T01:38:44Z
+ */
+
+export const VERSION = '0.1.8';

--- a/packages/external-match/tsconfig.build.json
+++ b/packages/external-match/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"],
+    "compilerOptions": {
+        "sourceMap": true
+    }
+}

--- a/packages/external-match/tsconfig.json
+++ b/packages/external-match/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.build.json",
+    "include": ["src/**/*.ts", "test/**/*.ts"],
+    "exclude": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,70 +33,6 @@ importers:
         specifier: ^1.5.0
         version: 1.6.0(@types/node@20.16.1)(happy-dom@12.10.3)
 
-  examples/external-match/in-kind-gas-sponsorship:
-    dependencies:
-      '@renegade-fi/renegade-sdk':
-        specifier: latest
-        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
-      viem:
-        specifier: ^2.34.0
-        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
-    devDependencies:
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.4
-      typescript:
-        specifier: ^5.0.3
-        version: 5.5.4
-
-  examples/external-match/native-gas-sponshorship:
-    dependencies:
-      '@renegade-fi/renegade-sdk':
-        specifier: latest
-        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
-      viem:
-        specifier: ^2.34.0
-        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
-    devDependencies:
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.4
-      typescript:
-        specifier: ^5.0.3
-        version: 5.5.4
-
-  examples/external-match/supported-tokens:
-    dependencies:
-      '@renegade-fi/renegade-sdk':
-        specifier: latest
-        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
-      viem:
-        specifier: ^2.34.0
-        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
-    devDependencies:
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.4
-      typescript:
-        specifier: ^5.0.3
-        version: 5.5.4
-
-  examples/external-match/token-prices:
-    dependencies:
-      '@renegade-fi/renegade-sdk':
-        specifier: latest
-        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
-      viem:
-        specifier: ^2.34.0
-        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
-    devDependencies:
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.4
-      typescript:
-        specifier: ^5.0.3
-        version: 5.5.4
-
   packages/core:
     dependencies:
       axios:
@@ -358,21 +294,9 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.25.9':
-    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.25.9':
-    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
-    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -382,21 +306,9 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.25.9':
-    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.9':
-    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -406,21 +318,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.25.9':
-    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.9':
-    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -430,21 +330,9 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.9':
-    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -454,21 +342,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.25.9':
-    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.9':
-    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
-    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -478,21 +354,9 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.9':
-    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.9':
-    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
-    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -502,21 +366,9 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.9':
-    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.9':
-    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
-    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -526,21 +378,9 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.9':
-    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.9':
-    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
-    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -550,35 +390,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.9':
-    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.9':
-    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -586,27 +402,9 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.9':
-    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.9':
-    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.25.9':
-    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -616,33 +414,15 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.25.9':
-    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.9':
-    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.9':
-    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -689,10 +469,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@renegade-fi/renegade-sdk@0.1.8':
-    resolution: {integrity: sha512-tTUXevfEZAQc5NGijO7oYupuZ0E1lM2SnFbNlFYHhlJMYUvCkaNjh8nfrjRY6T6SrDUvl90S74pqRxy+gqL14Q==}
-    engines: {node: '>=18'}
 
   '@rollup/plugin-virtual@3.0.2':
     resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
@@ -1095,11 +871,6 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.25.9:
-    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -1180,9 +951,6 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
-
-  get-tsconfig@4.10.1:
-    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1503,9 +1271,6 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -1619,11 +1384,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  tsx@4.20.4:
-    resolution: {integrity: sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
@@ -2033,148 +1793,70 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.9':
-    optional: true
-
   '@esbuild/android-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
-  '@esbuild/android-arm@0.25.9':
-    optional: true
-
   '@esbuild/android-x64@0.21.5':
-    optional: true
-
-  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.9':
-    optional: true
-
   '@esbuild/darwin-x64@0.21.5':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    optional: true
-
   '@esbuild/freebsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.9':
-    optional: true
-
   '@esbuild/linux-arm@0.21.5':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.9':
-    optional: true
-
   '@esbuild/linux-loong64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.9':
-    optional: true
-
   '@esbuild/linux-ppc64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.9':
-    optional: true
-
   '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
-  '@esbuild/linux-x64@0.25.9':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.9':
-    optional: true
-
   '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.9':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.9':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.9':
-    optional: true
-
   '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.9':
-    optional: true
-
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.9':
-    optional: true
-
   '@esbuild/win32-x64@0.21.5':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@jest/schemas@29.6.3':
@@ -2224,17 +1906,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
-
-  '@renegade-fi/renegade-sdk@0.1.8(typescript@5.5.4)(zod@3.23.8)':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      json-bigint: 1.0.0
-      viem: 2.34.0(typescript@5.5.4)(zod@3.23.8)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
 
   '@rollup/plugin-virtual@3.0.2(rollup@4.21.0)':
     optionalDependencies:
@@ -2589,35 +2260,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
-  esbuild@0.25.9:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.9
-      '@esbuild/android-arm': 0.25.9
-      '@esbuild/android-arm64': 0.25.9
-      '@esbuild/android-x64': 0.25.9
-      '@esbuild/darwin-arm64': 0.25.9
-      '@esbuild/darwin-x64': 0.25.9
-      '@esbuild/freebsd-arm64': 0.25.9
-      '@esbuild/freebsd-x64': 0.25.9
-      '@esbuild/linux-arm': 0.25.9
-      '@esbuild/linux-arm64': 0.25.9
-      '@esbuild/linux-ia32': 0.25.9
-      '@esbuild/linux-loong64': 0.25.9
-      '@esbuild/linux-mips64el': 0.25.9
-      '@esbuild/linux-ppc64': 0.25.9
-      '@esbuild/linux-riscv64': 0.25.9
-      '@esbuild/linux-s390x': 0.25.9
-      '@esbuild/linux-x64': 0.25.9
-      '@esbuild/netbsd-arm64': 0.25.9
-      '@esbuild/netbsd-x64': 0.25.9
-      '@esbuild/openbsd-arm64': 0.25.9
-      '@esbuild/openbsd-x64': 0.25.9
-      '@esbuild/openharmony-arm64': 0.25.9
-      '@esbuild/sunos-x64': 0.25.9
-      '@esbuild/win32-arm64': 0.25.9
-      '@esbuild/win32-ia32': 0.25.9
-      '@esbuild/win32-x64': 0.25.9
-
   escape-string-regexp@1.0.5: {}
 
   esprima@4.0.1: {}
@@ -2705,10 +2347,6 @@ snapshots:
   get-func-name@2.0.2: {}
 
   get-stream@8.0.1: {}
-
-  get-tsconfig@4.10.1:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -3008,8 +2646,6 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
-
   reusify@1.0.4: {}
 
   rollup@4.21.0:
@@ -3112,13 +2748,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  tsx@4.20.4:
-    dependencies:
-      esbuild: 0.25.9
-      get-tsconfig: 4.10.1
-    optionalDependencies:
-      fsevents: 2.3.3
 
   type-detect@4.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,70 @@ importers:
         specifier: ^1.5.0
         version: 1.6.0(@types/node@20.16.1)(happy-dom@12.10.3)
 
+  examples/external-match/in-kind-gas-sponsorship:
+    dependencies:
+      '@renegade-fi/renegade-sdk':
+        specifier: latest
+        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
+      viem:
+        specifier: ^2.34.0
+        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
+    devDependencies:
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.4
+      typescript:
+        specifier: ^5.0.3
+        version: 5.5.4
+
+  examples/external-match/native-gas-sponshorship:
+    dependencies:
+      '@renegade-fi/renegade-sdk':
+        specifier: latest
+        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
+      viem:
+        specifier: ^2.34.0
+        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
+    devDependencies:
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.4
+      typescript:
+        specifier: ^5.0.3
+        version: 5.5.4
+
+  examples/external-match/supported-tokens:
+    dependencies:
+      '@renegade-fi/renegade-sdk':
+        specifier: latest
+        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
+      viem:
+        specifier: ^2.34.0
+        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
+    devDependencies:
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.4
+      typescript:
+        specifier: ^5.0.3
+        version: 5.5.4
+
+  examples/external-match/token-prices:
+    dependencies:
+      '@renegade-fi/renegade-sdk':
+        specifier: latest
+        version: 0.1.8(typescript@5.5.4)(zod@3.23.8)
+      viem:
+        specifier: ^2.34.0
+        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
+    devDependencies:
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.4
+      typescript:
+        specifier: ^5.0.3
+        version: 5.5.4
+
   packages/core:
     dependencies:
       axios:
@@ -60,6 +124,22 @@ importers:
       '@tanstack/query-core':
         specifier: '>=5.0.0'
         version: 5.52.0
+      '@types/json-bigint':
+        specifier: ^1.0.4
+        version: 1.0.4
+
+  packages/external-match:
+    dependencies:
+      '@noble/hashes':
+        specifier: ^1.7.1
+        version: 1.8.0
+      json-bigint:
+        specifier: ^1.0.0
+        version: 1.0.0
+      viem:
+        specifier: ^2.23.15
+        version: 2.34.0(typescript@5.5.4)(zod@3.23.8)
+    devDependencies:
       '@types/json-bigint':
         specifier: ^1.0.4
         version: 1.0.4
@@ -156,6 +236,9 @@ packages:
 
   '@adraffy/ens-normalize@1.10.0':
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
+
+  '@adraffy/ens-normalize@1.11.0':
+    resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
   '@babel/runtime@7.25.4':
     resolution: {integrity: sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==}
@@ -275,9 +358,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -287,9 +382,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -299,9 +406,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -311,9 +430,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -323,9 +454,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -335,9 +478,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -347,9 +502,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -359,9 +526,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -371,11 +550,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -383,9 +586,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -395,15 +616,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -420,12 +659,24 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.4.0':
     resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
+
+  '@noble/curves@1.9.6':
+    resolution: {integrity: sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -438,6 +689,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@renegade-fi/renegade-sdk@0.1.8':
+    resolution: {integrity: sha512-tTUXevfEZAQc5NGijO7oYupuZ0E1lM2SnFbNlFYHhlJMYUvCkaNjh8nfrjRY6T6SrDUvl90S74pqRxy+gqL14Q==}
+    engines: {node: '>=18'}
 
   '@rollup/plugin-virtual@3.0.2':
     resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
@@ -536,11 +791,20 @@ packages:
   '@scure/base@1.1.7':
     resolution: {integrity: sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -669,6 +933,17 @@ packages:
 
   abitype@1.0.5:
     resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.0.8:
+    resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
@@ -820,6 +1095,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -831,6 +1111,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -897,6 +1180,9 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -969,6 +1255,11 @@ packages:
 
   isows@1.0.6:
     resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
+    peerDependencies:
+      ws: '*'
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
 
@@ -1076,6 +1367,14 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  ox@0.8.7:
+    resolution: {integrity: sha512-W1f0FiMf9NZqtHPEDEAEkyzZDwbIKfmH2qmQx8NNiQ/9JhxrSblmtLJsSfTtQG5YKowLOnBlLVguCyxm/7ztxw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -1204,6 +1503,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -1318,6 +1620,11 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tsx@4.20.4:
+    resolution: {integrity: sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
@@ -1348,6 +1655,14 @@ packages:
 
   viem@2.20.0:
     resolution: {integrity: sha512-cM4vs81HnSNbfceI1MLkx4pCVzbVjl9xiNSv5SCutYjUyFFOVSPDlEyhpg2iHinxx1NM4Qne3END5eLT8rvUdg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.34.0:
+    resolution: {integrity: sha512-HJZG9Wt0DLX042MG0PK17tpataxtdAEhpta9/Q44FqKwy3xZMI5Lx4jF+zZPuXFuYjZ68R0PXqRwlswHs6r4gA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1470,6 +1785,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
 
@@ -1505,6 +1832,8 @@ packages:
 snapshots:
 
   '@adraffy/ens-normalize@1.10.0': {}
+
+  '@adraffy/ens-normalize@1.11.0': {}
 
   '@babel/runtime@7.25.4':
     dependencies:
@@ -1704,70 +2033,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@jest/schemas@29.6.3':
@@ -1792,11 +2199,19 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/curves@1.4.0':
     dependencies:
       '@noble/hashes': 1.4.0
 
+  '@noble/curves@1.9.6':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/hashes@1.4.0': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1809,6 +2224,17 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@renegade-fi/renegade-sdk@0.1.8(typescript@5.5.4)(zod@3.23.8)':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      json-bigint: 1.0.0
+      viem: 2.34.0(typescript@5.5.4)(zod@3.23.8)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
 
   '@rollup/plugin-virtual@3.0.2(rollup@4.21.0)':
     optionalDependencies:
@@ -1867,16 +2293,29 @@ snapshots:
 
   '@scure/base@1.1.7': {}
 
+  '@scure/base@1.2.6': {}
+
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.7
 
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.7
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -1992,6 +2431,11 @@ snapshots:
       pretty-format: 29.7.0
 
   abitype@1.0.5(typescript@5.5.4)(zod@3.23.8):
+    optionalDependencies:
+      typescript: 5.5.4
+      zod: 3.23.8
+
+  abitype@1.0.8(typescript@5.5.4)(zod@3.23.8):
     optionalDependencies:
       typescript: 5.5.4
       zod: 3.23.8
@@ -2145,6 +2589,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
+
   escape-string-regexp@1.0.5: {}
 
   esprima@4.0.1: {}
@@ -2152,6 +2625,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.5
+
+  eventemitter3@5.0.1: {}
 
   execa@8.0.1:
     dependencies:
@@ -2231,6 +2706,10 @@ snapshots:
 
   get-stream@8.0.1: {}
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -2296,6 +2775,10 @@ snapshots:
   isows@1.0.6(ws@8.17.1):
     dependencies:
       ws: 8.17.1
+
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
 
   js-tokens@4.0.0: {}
 
@@ -2398,6 +2881,21 @@ snapshots:
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
+
+  ox@0.8.7(typescript@5.5.4)(zod@3.23.8):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.5.4)(zod@3.23.8)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - zod
 
   p-filter@2.1.0:
     dependencies:
@@ -2510,6 +3008,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   reusify@1.0.4: {}
 
   rollup@4.21.0:
@@ -2613,6 +3113,13 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tsx@4.20.4:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-detect@4.1.0: {}
 
   typescript@5.5.4: {}
@@ -2640,6 +3147,23 @@ snapshots:
       isows: 1.0.4(ws@8.17.1)
       webauthn-p256: 0.0.5
       ws: 8.17.1
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.34.0(typescript@5.5.4)(zod@3.23.8):
+    dependencies:
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.5.4)(zod@3.23.8)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.8.7(typescript@5.5.4)(zod@3.23.8)
+      ws: 8.18.3
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -2726,7 +3250,7 @@ snapshots:
   webauthn-p256@0.0.5:
     dependencies:
       '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.8.0
 
   webidl-conversions@7.0.0: {}
 
@@ -2755,6 +3279,8 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.17.1: {}
+
+  ws@8.18.3: {}
 
   yallist@2.1.2: {}
 


### PR DESCRIPTION
### Purpose
This PR moves the contents of https://github.com/renegade-fi/typescript-external-match-client into the packages/external-match directory. It also updates external match examples to be compatible, and removes the old external match client.

No changes were made to the external match client code, except for adding `.js` extensions to import paths.

### Testing
- [x] Tested that all examples run 