### PR TITLE
chore: fix lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
     "files": {
         "includes": [
             "**",
@@ -7,9 +7,9 @@
             "!**/pnpm-lock.yaml",
             "!**/package.json",
             "!**/tsconfig.base.json",
-            "!**/wasm/**",
-            "!**/dist/**",
-            "!**/renegade-utils/**",
+            "!**/wasm",
+            "!**/dist",
+            "!**/renegade-utils",
             "!**/*.d.ts",
             "!**/version.ts"
         ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "^2.2.0",
         "@changesets/cli": "^2.27.1",
         "@types/node": "^20.12.7",
         "typescript": "^5.5.4"

--- a/packages/core/src/actions/payFees.ts
+++ b/packages/core/src/actions/payFees.ts
@@ -15,7 +15,7 @@ export async function payFees(config: RenegadeConfig): Promise<PayFeesReturnType
     try {
         const res = await postRelayerWithAuth(config, getBaseUrl(PAY_FEES_ROUTE(walletId)));
         if (res?.task_ids) {
-            res.task_ids.map((id: string) => {
+            res.task_ids.forEach((id: string) => {
                 console.log(`task pay-fees(${id}): ${walletId}`);
             });
         }

--- a/packages/core/src/query/utils.ts
+++ b/packages/core/src/query/utils.ts
@@ -20,7 +20,7 @@ export function hashFn(queryKey: QueryKey): string {
     });
 }
 
-// biome-ignore lint/complexity/noBannedTypes: <explanation>
+// biome-ignore lint/complexity/noBannedTypes: from wagmi
 function isPlainObject(o: any): o is Object {
     if (!hasObjectPrototype(o)) {
         return false;
@@ -35,7 +35,7 @@ function isPlainObject(o: any): o is Object {
     if (!hasObjectPrototype(prot)) return false;
 
     // If constructor does not have an Object-specific method
-    // biome-ignore lint/suspicious/noPrototypeBuiltins: <explanation>
+    // biome-ignore lint/suspicious/noPrototypeBuiltins: from wagmi
     if (!prot.hasOwnProperty("isPrototypeOf")) return false;
 
     // Most likely a plain Object
@@ -47,7 +47,7 @@ function hasObjectPrototype(o: any): boolean {
 }
 
 export function filterQueryOptions<type extends Record<string, unknown>>(options: type): type {
-    // biome-ignore-start lint/correctness/noUnusedVariables: <explanation>
+    // biome-ignore-start lint/correctness/noUnusedVariables: from wagmi
     const {
         _defaulted,
         behavior,
@@ -89,7 +89,7 @@ export function filterQueryOptions<type extends Record<string, unknown>>(options
         query,
         ...rest
     } = options;
-    // biome-ignore-end lint/correctness/noUnusedVariables: <explanation>
+    // biome-ignore-end lint/correctness/noUnusedVariables: from wagmi
 
     return rest as type;
 }

--- a/packages/core/src/utils/cookie.ts
+++ b/packages/core/src/utils/cookie.ts
@@ -10,10 +10,12 @@ export const cookieStorage = {
     },
     setItem(key, value) {
         if (typeof window === "undefined") return;
+        // biome-ignore lint/suspicious/noDocumentCookie: from wagmi
         document.cookie = `${key}=${value}`;
     },
     removeItem(key) {
         if (typeof window === "undefined") return;
+        // biome-ignore lint/suspicious/noDocumentCookie: from wagmi
         document.cookie = `${key}=;max-age=-1`;
     },
 } satisfies BaseStorage;

--- a/packages/core/src/utils/deepEqual.ts
+++ b/packages/core/src/utils/deepEqual.ts
@@ -35,6 +35,6 @@ export function deepEqual(a: any, b: any) {
     }
 
     // true if both NaN, false otherwise
-    // biome-ignore lint/suspicious/noSelfCompare: <explanation>
+    // biome-ignore lint/suspicious/noSelfCompare: from wagmi
     return a !== a && b !== b;
 }

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -69,7 +69,7 @@ export async function getRelayerRaw(url: string, headers = {}) {
                     ) {
                         // We use ts-ignore here because TypeScript doesn't recognize the
                         // `context` argument in the JSON.parse reviver
-                        // @ts-ignore
+                        // @ts-expect-error
                         return JSON.parse(data, (key, value, context) => {
                             if (typeof value === "number" && key !== "price") {
                                 if (context?.source === undefined) {

--- a/packages/node/src/utils/permit2.ts
+++ b/packages/node/src/utils/permit2.ts
@@ -56,7 +56,7 @@ export async function signPermit2({
     walletClient: WalletClient;
     pkRoot: bigint[];
 }) {
-    if (!walletClient.account) throw new Error("`0x${string}` not found on wallet client");
+    if (!walletClient.account) throw new Error("Account not found on wallet client");
 
     // Construct Domain
     const domain: TypedDataDomain = {

--- a/packages/react/src/hooks/useConfig.ts
+++ b/packages/react/src/hooks/useConfig.ts
@@ -13,7 +13,7 @@ export type UseConfigReturnType<config extends Config = Config> = config | undef
 export function useConfig<config extends Config = Config>(
     parameters: UseConfigParameters<config> = {},
 ): UseConfigReturnType<config> {
-    // biome-ignore-start lint/correctness/useHookAtTopLevel: <explanation>
+    // biome-ignore lint/correctness/useHookAtTopLevel: from wagmi
     const config = parameters.config ?? useContext(RenegadeContext);
     return config as UseConfigReturnType<config>;
 }

--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -33,7 +33,7 @@ export function Hydrate(parameters: React.PropsWithChildren<HydrateProps>) {
 
     // Hydrate for SSR
     const active = useRef(true);
-    // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+    // biome-ignore lint/correctness/useExhaustiveDependencies: we only want to initialize once on mount
     useEffect(() => {
         if (!config) return;
         config.utils

--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -25,10 +25,14 @@ export function Hydrate(parameters: React.PropsWithChildren<HydrateProps>) {
     if (config && !config._internal.ssr) onMount();
 
     useEffect(() => {
-        RustUtils.default().then(() => {
-            setIsInitialized(true);
-            console.log("Backup effect initialized WASM");
-        });
+        RustUtils.default()
+            .then(() => {
+                setIsInitialized(true);
+                console.log("Backup effect initialized WASM");
+            })
+            .catch((error: unknown) => {
+                console.error("❌ Failed to initialize Rust utils", error);
+            });
     }, []);
 
     // Hydrate for SSR

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.2.0
+        version: 2.2.0
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.27.7
@@ -162,55 +162,55 @@ packages:
     resolution: {integrity: sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.0.0':
-    resolution: {integrity: sha512-BlUoXEOI/UQTDEj/pVfnkMo8SrZw3oOWBDrXYFT43V7HTkIUDkBRY53IC5Jx1QkZbaB+0ai1wJIfYwp9+qaJTQ==}
+  '@biomejs/biome@2.2.0':
+    resolution: {integrity: sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.0.0':
-    resolution: {integrity: sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw==}
+  '@biomejs/cli-darwin-arm64@2.2.0':
+    resolution: {integrity: sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.0.0':
-    resolution: {integrity: sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw==}
+  '@biomejs/cli-darwin-x64@2.2.0':
+    resolution: {integrity: sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.0.0':
-    resolution: {integrity: sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA==}
+  '@biomejs/cli-linux-arm64-musl@2.2.0':
+    resolution: {integrity: sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.0.0':
-    resolution: {integrity: sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw==}
+  '@biomejs/cli-linux-arm64@2.2.0':
+    resolution: {integrity: sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.0.0':
-    resolution: {integrity: sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA==}
+  '@biomejs/cli-linux-x64-musl@2.2.0':
+    resolution: {integrity: sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.0.0':
-    resolution: {integrity: sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg==}
+  '@biomejs/cli-linux-x64@2.2.0':
+    resolution: {integrity: sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.0.0':
-    resolution: {integrity: sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw==}
+  '@biomejs/cli-win32-arm64@2.2.0':
+    resolution: {integrity: sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.0.0':
-    resolution: {integrity: sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg==}
+  '@biomejs/cli-win32-x64@2.2.0':
+    resolution: {integrity: sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -924,39 +924,39 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@biomejs/biome@2.0.0':
+  '@biomejs/biome@2.2.0':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.0.0
-      '@biomejs/cli-darwin-x64': 2.0.0
-      '@biomejs/cli-linux-arm64': 2.0.0
-      '@biomejs/cli-linux-arm64-musl': 2.0.0
-      '@biomejs/cli-linux-x64': 2.0.0
-      '@biomejs/cli-linux-x64-musl': 2.0.0
-      '@biomejs/cli-win32-arm64': 2.0.0
-      '@biomejs/cli-win32-x64': 2.0.0
+      '@biomejs/cli-darwin-arm64': 2.2.0
+      '@biomejs/cli-darwin-x64': 2.2.0
+      '@biomejs/cli-linux-arm64': 2.2.0
+      '@biomejs/cli-linux-arm64-musl': 2.2.0
+      '@biomejs/cli-linux-x64': 2.2.0
+      '@biomejs/cli-linux-x64-musl': 2.2.0
+      '@biomejs/cli-win32-arm64': 2.2.0
+      '@biomejs/cli-win32-x64': 2.2.0
 
-  '@biomejs/cli-darwin-arm64@2.0.0':
+  '@biomejs/cli-darwin-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.0.0':
+  '@biomejs/cli-darwin-x64@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.0.0':
+  '@biomejs/cli-linux-arm64-musl@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.0.0':
+  '@biomejs/cli-linux-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.0.0':
+  '@biomejs/cli-linux-x64-musl@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.0.0':
+  '@biomejs/cli-linux-x64@2.2.0':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.0.0':
+  '@biomejs/cli-win32-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.0.0':
+  '@biomejs/cli-win32-x64@2.2.0':
     optional: true
 
   '@changesets/apply-release-plan@7.0.4':


### PR DESCRIPTION
### Purpose
This PR fixes lint errors so CI passes. Most were due to suppressions of code directly copied from the wagmi codebase. In the near future, we will deprecate the @renegade-fi/react package entirely, as it does not provide meaningful, react-specific helpers on top of `@renegade-fi/core` (all hooks have been re-implemented in https://github.com/renegade-fi/renegade-frontend).