### PR TITLE
core: add logger type

### DIFF
--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -1,0 +1,65 @@
+import type { Logger, LoggingOptions } from "./types.js";
+
+/**
+ * A logger that performs no operations. Used when no consumer logger is provided.
+ */
+export class NoopLogger implements Logger {
+    debug(): void {}
+    info(): void {}
+    warn(): void {}
+    error(): void {}
+}
+
+/**
+ * A thin console-backed logger primarily for development/testing.
+ * Not used by default; consumers should inject their own logger.
+ */
+export class ConsoleLogger implements Logger {
+    private readonly baseMeta: Record<string, unknown>;
+
+    constructor(options?: { baseMeta?: Record<string, unknown> }) {
+        this.baseMeta = options?.baseMeta ?? {};
+    }
+
+    /** Merge static base metadata into per-call metadata. */
+    private mix(meta?: Record<string, unknown>) {
+        return this.baseMeta && Object.keys(this.baseMeta).length > 0
+            ? { ...this.baseMeta, ...(meta ?? {}) }
+            : meta;
+    }
+
+    debug(message: string, meta?: Record<string, unknown>): void {
+        console.debug(message, this.mix(meta));
+    }
+    info(message: string, meta?: Record<string, unknown>): void {
+        console.info(message, this.mix(meta));
+    }
+    warn(message: string, meta?: Record<string, unknown>): void {
+        console.warn(message, this.mix(meta));
+    }
+    error(message: string, meta?: Record<string, unknown>): void {
+        console.error(message, this.mix(meta));
+    }
+
+    child(context: Record<string, unknown>): Logger {
+        const merged = { ...this.baseMeta, ...context };
+        return new ConsoleLogger({ baseMeta: merged });
+    }
+}
+
+export function createLogger(options?: LoggingOptions): Logger {
+    // Prefer consumer-provided logger if available
+    if (options?.logger) {
+        const base =
+            options.namespace && options.logger.child
+                ? options.logger.child({ ns: options.namespace })
+                : options.logger;
+        return base;
+    }
+    // Default to silent if no logger provided
+    return new NoopLogger();
+}
+
+export function childLogger(base: Logger, context: Record<string, unknown>): Logger {
+    return base.child ? base.child(context) : base;
+}

--- a/packages/core/src/logging/types.ts
+++ b/packages/core/src/logging/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Minimal logger interface used by the SDK.
+ *
+ * Implement this interface to integrate your logging library (e.g. pino, winston).
+ * The SDK does not log by default; provide a logger via `createConfig({ logging: { logger } })`.
+ */
+export interface Logger {
+    /** Log verbose diagnostic details useful for debugging. */
+    debug(message: string, meta?: Record<string, unknown>): void;
+    /** Log general informational messages about normal operations. */
+    info(message: string, meta?: Record<string, unknown>): void;
+    /** Log recoverable issues or potential problems. */
+    warn(message: string, meta?: Record<string, unknown>): void;
+    /** Log errors and unexpected failures. */
+    error(message: string, meta?: Record<string, unknown>): void;
+    /**
+     * Optionally derive a namespaced child logger with static context.
+     * If unsupported, return the base logger.
+     */
+    child?(context: Record<string, unknown>): Logger;
+}
+
+/**
+ * Logging configuration passed to `createConfig` or `createExternalKeyConfig`.
+ */
+export type LoggingOptions = {
+    /**
+     * Your logger implementation. If omitted, logging is silent by default.
+     */
+    logger?: Logger;
+    /**
+     * Optional namespace applied at creation time via `logger.child({ ns })` when supported.
+     */
+    namespace?: string;
+};


### PR DESCRIPTION
### Purpose
This PR adds an interface for a logger that consumers can provide to listen for log events at a given level. In the next PR we will replace instances of `console.log` by invoking this logger.
