### PR TITLE
chore: pin to safe versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,16 @@
         "lint": "biome check .",
         "typecheck": "pnpm run --r --parallel typecheck"
     },
-    "packageManager": "pnpm@9.1.4+sha512.9df9cf27c91715646c7d675d1c9c8e41f6fce88246f1318c1aa6a1ed1aeb3c4f032fcdf4ba63cc69c4fe6d634279176b5358727d8f2cc1e65b65f43ce2f8bfb0"
+    "packageManager": "pnpm@9.1.4+sha512.9df9cf27c91715646c7d675d1c9c8e41f6fce88246f1318c1aa6a1ed1aeb3c4f032fcdf4ba63cc69c4fe6d634279176b5358727d8f2cc1e65b65f43ce2f8bfb0",
+    "pnpm": {
+        "overrides": {
+          "chalk": "2.4.2",
+          "ansi-styles": "3.2.1",
+          "color-convert": "1.9.3",
+          "color-name": "1.1.3",
+          "supports-color": "5.5.0",
+          "strip-ansi": "6.0.1",
+          "ansi-regex": "5.0.1"
+        }
+      }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.9.11
+
+### Patch Changes
+
+- chore: pin safe versions
+
 ## 0.9.10
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/core",
     "description": "VanillaJS library for Renegade",
-    "version": "0.9.10",
+    "version": "0.9.11",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.10'
+export const version = '0.9.11'

--- a/packages/external-match/CHANGELOG.md
+++ b/packages/external-match/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/renegade-sdk
 
+## 0.1.10
+
+### Patch Changes
+
+- chore: pin safe versions
+
 ## 0.1.9
 
 ### Patch Changes

--- a/packages/external-match/package.json
+++ b/packages/external-match/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/renegade-sdk",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "A TypeScript client for interacting with the Renegade Darkpool API",
     "repository": {
         "type": "git",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.6.16
+
+### Patch Changes
+
+- chore: pin safe versions
+- Updated dependencies
+  - @renegade-fi/core@0.9.11
+
 ## 0.6.15
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/node",
     "description": "Node.js library for Renegade",
-    "version": "0.6.15",
+    "version": "0.6.16",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/price-reporter/CHANGELOG.md
+++ b/packages/price-reporter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @renegade-fi/price-reporter
 
+## 0.0.30
+
+### Patch Changes
+
+- chore: pin safe versions
+- Updated dependencies
+  - @renegade-fi/core@0.9.11
+  - @renegade-fi/token@0.0.30
+
 ## 0.0.29
 
 ### Patch Changes

--- a/packages/price-reporter/package.json
+++ b/packages/price-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/price-reporter",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "A TypeScript client for interacting with the Price Reporter",
     "files": [
         "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/react
 
+## 0.6.26
+
+### Patch Changes
+
+- chore: pin safe versions
+- Updated dependencies
+  - @renegade-fi/core@0.9.11
+
 ## 0.6.25
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@renegade-fi/react",
     "description": "React library for Renegade",
-    "version": "0.6.25",
+    "version": "0.6.26",
     "repository": {
         "type": "git",
         "url": "https://github.com/renegade-fi/typescript-sdk.git",

--- a/packages/token-nextjs/CHANGELOG.md
+++ b/packages/token-nextjs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @renegade-fi/token-nextjs
 
+## 0.1.16
+
+### Patch Changes
+
+- chore: pin safe versions
+- Updated dependencies
+  - @renegade-fi/core@0.9.11
+  - @renegade-fi/token@0.0.30
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/token-nextjs/package.json
+++ b/packages/token-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token-nextjs",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "description": "Token remapping for Renegade, preconfigured for Next.js",
     "files": [
         "dist/**",

--- a/packages/token/CHANGELOG.md
+++ b/packages/token/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/token
 
+## 0.0.30
+
+### Patch Changes
+
+- chore: pin safe versions
+- Updated dependencies
+  - @renegade-fi/core@0.9.11
+
 ## 0.0.29
 
 ### Patch Changes

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/token",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Token remapping for Renegade",
     "files": [
         "dist/**",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/types
 
+## 0.0.6
+
+### Patch Changes
+
+- chore: pin safe versions
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renegade-fi/types",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Types for the Renegade SDK",
     "repository": {
         "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  chalk: 2.4.2
+  ansi-styles: 3.2.1
+  color-convert: 1.9.3
+  color-name: 1.1.3
+  supports-color: 5.5.0
+  strip-ansi: 6.0.1
+  ansi-regex: 5.0.1
+
 importers:
 
   .:
@@ -28,10 +37,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -47,10 +56,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -66,10 +75,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -85,10 +94,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -104,10 +113,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -123,10 +132,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -142,10 +151,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -161,10 +170,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -180,10 +189,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -199,10 +208,10 @@ importers:
         version: 2.3.0
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -215,10 +224,10 @@ importers:
     dependencies:
       '@renegade-fi/renegade-sdk':
         specifier: latest
-        version: 0.1.9(typescript@5.5.4)(zod@3.23.8)
+        version: 0.1.9(typescript@5.5.4)(zod@4.0.5)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4
@@ -231,10 +240,10 @@ importers:
     dependencies:
       '@renegade-fi/renegade-sdk':
         specifier: latest
-        version: 0.1.9(typescript@5.5.4)(zod@3.23.8)
+        version: 0.1.9(typescript@5.5.4)(zod@4.0.5)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4
@@ -247,10 +256,10 @@ importers:
     dependencies:
       '@renegade-fi/renegade-sdk':
         specifier: latest
-        version: 0.1.9(typescript@5.5.4)(zod@3.23.8)
+        version: 0.1.9(typescript@5.5.4)(zod@4.0.5)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4
@@ -263,10 +272,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -279,10 +288,10 @@ importers:
     dependencies:
       '@renegade-fi/renegade-sdk':
         specifier: latest
-        version: 0.1.9(typescript@5.5.4)(zod@3.23.8)
+        version: 0.1.9(typescript@5.5.4)(zod@4.0.5)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4
@@ -295,10 +304,10 @@ importers:
     dependencies:
       '@renegade-fi/renegade-sdk':
         specifier: latest
-        version: 0.1.9(typescript@5.5.4)(zod@3.23.8)
+        version: 0.1.9(typescript@5.5.4)(zod@4.0.5)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4
@@ -311,10 +320,10 @@ importers:
     dependencies:
       '@renegade-fi/renegade-sdk':
         specifier: latest
-        version: 0.1.9(typescript@5.5.4)(zod@3.23.8)
+        version: 0.1.9(typescript@5.5.4)(zod@4.0.5)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4
@@ -327,10 +336,10 @@ importers:
     dependencies:
       '@renegade-fi/renegade-sdk':
         specifier: latest
-        version: 0.1.9(typescript@5.5.4)(zod@3.23.8)
+        version: 0.1.9(typescript@5.5.4)(zod@4.0.5)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4
@@ -343,10 +352,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -359,10 +368,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -375,10 +384,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -391,10 +400,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -404,10 +413,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -420,10 +429,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -436,10 +445,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -452,10 +461,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -468,10 +477,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -484,10 +493,10 @@ importers:
     dependencies:
       '@renegade-fi/node':
         specifier: latest
-        version: 0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -500,10 +509,10 @@ importers:
     dependencies:
       '@renegade-fi/token':
         specifier: latest
-        version: 0.0.28(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.0.29(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -516,10 +525,10 @@ importers:
     dependencies:
       '@renegade-fi/token':
         specifier: latest
-        version: 0.0.28(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+        version: 0.0.29(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       viem:
         specifier: latest
-        version: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+        version: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     devDependencies:
       tsx:
         specifier: ^4.20.3
@@ -946,6 +955,10 @@ packages:
   '@noble/curves@1.4.0':
     resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
 
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.6':
     resolution: {integrity: sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==}
     engines: {node: ^14.21.3 || >=16}
@@ -973,8 +986,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@renegade-fi/core@0.9.9':
-    resolution: {integrity: sha512-WM1ynwNy0Qa+Dd3Ui6RQQL9VyXWhUN8awUk09TRphi5VX6MDMi2fWVfl9A165Tin3hSLk5psAyAqYuGQm2cOMA==}
+  '@renegade-fi/core@0.9.10':
+    resolution: {integrity: sha512-d8En/lyqAqOhhq+AtxHamm8kkjnTjgRhHwg74eO1cpOcJfXe5C6yab/U7008GEJehwLxv0IhgjGYhUXujDwJrQ==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       viem: 2.x
@@ -982,16 +995,16 @@ packages:
       '@tanstack/query-core':
         optional: true
 
-  '@renegade-fi/node@0.6.14':
-    resolution: {integrity: sha512-IY4cNPVCru11jaZ5r6jVPhNnDpJYPZ/CiEouEkB9bpqpssjetgYG616SyNK78BL2A9Vcv3Wq91Ltge9axhteXA==}
+  '@renegade-fi/node@0.6.15':
+    resolution: {integrity: sha512-xkl7B/qoBvAgHqfYAeuCk+8dLep/OwC+pSXN8ebGtZYNnXfvufFb7CGHJN9Cx/X63MQLcERm7n/+V8pQNk/oaA==}
     peerDependencies:
       viem: 2.x
 
   '@renegade-fi/renegade-sdk@0.1.9':
     resolution: {integrity: sha512-mua0Kpffr9DbTFpIzBF6QhqLGhB8I+4PbRZal0kl2Xjjv69uzNHU65Wg4F/mSB4vqzIIHkuwNSGAP4LpMQ0ZNg==}
 
-  '@renegade-fi/token@0.0.28':
-    resolution: {integrity: sha512-LlxXX+Ci+qI2lbCVv33aFHQ0qMlnEh7xgqRCQgN3rX9CXrdA3OtTtWHwW9COIoKzjG1/frrlQKVGdUY/w8V7zg==}
+  '@renegade-fi/token@0.0.29':
+    resolution: {integrity: sha512-OGtvFng70rf+QvHLksLn52sXqczA70c0ZbwwJ6zsNKeqSgn+lji/wBTcjWyNH+g+/i6Xi0CJoAvlgfDuN+JP6w==}
 
   '@rollup/rollup-linux-x64-gnu@4.35.0':
     resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
@@ -1061,6 +1074,17 @@ packages:
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.1.0:
+    resolution: {integrity: sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1359,8 +1383,8 @@ packages:
       typescript:
         optional: true
 
-  ox@0.9.1:
-    resolution: {integrity: sha512-NVI0cajROntJWtFnxZQ1aXDVy+c6DLEXJ3wwON48CgbPhmMJrpRTfVbuppR+47RmXm3lZ/uMaKiFSkLdAO1now==}
+  ox@0.9.3:
+    resolution: {integrity: sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -1566,8 +1590,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.36.0:
-    resolution: {integrity: sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ==}
+  viem@2.37.4:
+    resolution: {integrity: sha512-1ig5O6l1wJmaw3yrSrUimjRLQEZon2ymTqSDjdntu6Bry1/tLC2GClXeS3SiCzrifpLxzfCLQWDITYVTBA10KA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1938,6 +1962,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.4.0
 
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@1.9.6':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -1960,14 +1988,14 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@renegade-fi/core@0.9.9(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)':
+  '@renegade-fi/core@0.9.10(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)':
     dependencies:
       axios: 1.7.5
       isows: 1.0.7(ws@8.18.3)
       json-bigint: 1.0.0
       neverthrow: 8.2.0
       tiny-invariant: 1.3.3
-      viem: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+      viem: 2.37.4(typescript@5.5.4)(zod@4.0.5)
       zustand: 4.5.5(@types/react@18.3.4)(react@18.3.1)
     optionalDependencies:
       '@tanstack/query-core': 5.52.0
@@ -1978,11 +2006,11 @@ snapshots:
       - react
       - ws
 
-  '@renegade-fi/node@0.6.14(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)':
+  '@renegade-fi/node@0.6.15(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)':
     dependencies:
-      '@renegade-fi/core': 0.9.9(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+      '@renegade-fi/core': 0.9.10(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
       tiny-invariant: 1.3.3
-      viem: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+      viem: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     transitivePeerDependencies:
       - '@tanstack/query-core'
       - '@types/react'
@@ -1991,20 +2019,20 @@ snapshots:
       - react
       - ws
 
-  '@renegade-fi/renegade-sdk@0.1.9(typescript@5.5.4)(zod@3.23.8)':
+  '@renegade-fi/renegade-sdk@0.1.9(typescript@5.5.4)(zod@4.0.5)':
     dependencies:
       '@noble/hashes': 1.8.0
       json-bigint: 1.0.0
-      viem: 2.36.0(typescript@5.5.4)(zod@3.23.8)
+      viem: 2.37.4(typescript@5.5.4)(zod@4.0.5)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@renegade-fi/token@0.0.28(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)':
+  '@renegade-fi/token@0.0.29(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)':
     dependencies:
-      '@renegade-fi/core': 0.9.9(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.36.0(typescript@5.5.4)(zod@3.23.8))(ws@8.18.3)
+      '@renegade-fi/core': 0.9.10(@tanstack/query-core@5.52.0)(@types/react@18.3.4)(react@18.3.1)(viem@2.37.4(typescript@5.5.4)(zod@4.0.5))(ws@8.18.3)
     transitivePeerDependencies:
       - '@tanstack/query-core'
       - '@types/react'
@@ -2080,6 +2108,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
       zod: 3.23.8
+
+  abitype@1.1.0(typescript@5.5.4)(zod@4.0.5):
+    optionalDependencies:
+      typescript: 5.5.4
+      zod: 4.0.5
 
   ansi-colors@4.1.3: {}
 
@@ -2389,15 +2422,15 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.1(typescript@5.5.4)(zod@3.23.8):
+  ox@0.9.3(typescript@5.5.4)(zod@4.0.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.6
+      '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.5.4)(zod@3.23.8)
+      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.5.4
@@ -2588,15 +2621,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.36.0(typescript@5.5.4)(zod@3.23.8):
+  viem@2.37.4(typescript@5.5.4)(zod@4.0.5):
     dependencies:
-      '@noble/curves': 1.9.6
+      '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.5.4)(zod@3.23.8)
+      abitype: 1.1.0(typescript@5.5.4)(zod@4.0.5)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.9.1(typescript@5.5.4)(zod@3.23.8)
+      ox: 0.9.3(typescript@5.5.4)(zod@4.0.5)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.5.4
@@ -2607,7 +2640,7 @@ snapshots:
 
   webauthn-p256@0.0.5:
     dependencies:
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.9.6
       '@noble/hashes': 1.8.0
 
   which-pm@2.2.0:


### PR DESCRIPTION
### Purpose
This PR pins dependencies listed as compromised [here](https://github.com/debug-js/debug/issues/1005#issuecomment-3266868187) to versions that are not the compromised versions _and_ the same versions that were already in the lockfile. This is to avoid pulling in new versions. 

Current versions were found by running
`pnpm why chalk strip-ansi color-convert color-name is-core-module error-ex has-ansi`